### PR TITLE
Redesign landing page and optimize route performance for Hobby tier

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,4 +1,9 @@
-export const maxDuration = 60;
+// Was 60s. Multi-platform campaigns (X + LinkedIn + Discord + Slack + Email)
+// can take 25-50s on a clean call; the lexicon validator's repair retry can
+// add another full Gemini call. 180s gives us headroom for both, matching
+// the long-form route. The retry itself is also gated by a runtime budget
+// guard below so we never push the function to the edge of this limit.
+export const maxDuration = 180;
 import { NextResponse } from 'next/server';
 import { buildGenerationPrompt, containsPromptInjection } from '../../../lib/prompts';
 import {
@@ -104,9 +109,19 @@ async function generateFromParts(parts: any[], stream = false) {
  * because LLMs occasionally use a flagged word in a sentence the lexicon
  * was never meant to catch.
  */
+// Hard budget for the entire generation slot, including the optional retry.
+// Stays well below `maxDuration` so the route can finish persisting + return
+// JSON before Vercel kills the function. Lower it on a faster Vertex tier.
+const GENERATION_BUDGET_MS = 150_000;
+// Minimum runtime headroom required before we'll START a repair retry.
+// A clean Gemini call on a 5-platform campaign averages 25-50s; we need at
+// least this much remaining budget or we ship the original with warnings.
+const RETRY_MIN_REMAINING_MS = 60_000;
+
 async function generateWithLexiconGuard(
   parts: any[],
-  basePrompt: string
+  basePrompt: string,
+  startTime: number
 ): Promise<{ responseText: string; report: ValidationReport; retried: boolean }> {
   const initial = await generateFromParts(parts);
 
@@ -132,8 +147,20 @@ async function generateWithLexiconGuard(
     return { responseText: initial, report, retried: false };
   }
 
+  // Time-budget guard: never start a retry that could push us past the
+  // function timeout. Better to ship a flagged draft than time out and
+  // ship nothing.
+  const elapsed = Date.now() - startTime;
+  const remaining = GENERATION_BUDGET_MS - elapsed;
+  if (remaining < RETRY_MIN_REMAINING_MS) {
+    console.warn(
+      `[lexicon] skipping repair retry: only ${remaining}ms of budget left (need ${RETRY_MIN_REMAINING_MS}ms). Returning original with ${report.violations.length} violation(s).`
+    );
+    return { responseText: initial, report, retried: false };
+  }
+
   console.log(
-    `[lexicon] initial output had ${report.violations.length} violation(s) (slop=${report.slopScore}); retrying with repair directive`
+    `[lexicon] initial output had ${report.violations.length} violation(s) (slop=${report.slopScore}); retrying with repair directive (${remaining}ms budget remaining)`
   );
 
   const repairDirective = buildRepairDirective(report);
@@ -265,7 +292,7 @@ export async function POST(req: Request) {
       }
 
       const { responseText, report: lexiconReport, retried } =
-        await generateWithLexiconGuard(parts, textPrompt);
+        await generateWithLexiconGuard(parts, textPrompt, startTime);
       const lexiconWarnings = summarizeForClient(lexiconReport);
 
       const durationMs = Date.now() - startTime;
@@ -429,7 +456,7 @@ export async function POST(req: Request) {
     }
 
     const { responseText, report: lexiconReport, retried } =
-      await generateWithLexiconGuard(parts, textPrompt);
+      await generateWithLexiconGuard(parts, textPrompt, startTime);
     const lexiconWarnings = summarizeForClient(lexiconReport);
 
     await incrementCampaignGeneration(user.id);

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,9 +1,8 @@
-// Was 60s. Multi-platform campaigns (X + LinkedIn + Discord + Slack + Email)
-// can take 25-50s on a clean call; the lexicon validator's repair retry can
-// add another full Gemini call. 180s gives us headroom for both, matching
-// the long-form route. The retry itself is also gated by a runtime budget
-// guard below so we never push the function to the edge of this limit.
-export const maxDuration = 180;
+// Vercel Hobby tier caps function runtime at 60s. Anything declared above
+// that is silently capped, so we set 60 explicitly and rely on the budget
+// guard below to skip the lexicon repair retry whenever the initial call
+// already consumed most of the runtime. Upgrade to Pro to raise this to 300.
+export const maxDuration = 60;
 import { NextResponse } from 'next/server';
 import { buildGenerationPrompt, containsPromptInjection } from '../../../lib/prompts';
 import {
@@ -109,14 +108,14 @@ async function generateFromParts(parts: any[], stream = false) {
  * because LLMs occasionally use a flagged word in a sentence the lexicon
  * was never meant to catch.
  */
-// Hard budget for the entire generation slot, including the optional retry.
-// Stays well below `maxDuration` so the route can finish persisting + return
-// JSON before Vercel kills the function. Lower it on a faster Vertex tier.
-const GENERATION_BUDGET_MS = 150_000;
+// Hard budget for the entire generation slot, sized for Hobby (60s cap).
+// Leaves ~5s for DB persist + JSON return + PostHog flush.
+const GENERATION_BUDGET_MS = 55_000;
 // Minimum runtime headroom required before we'll START a repair retry.
-// A clean Gemini call on a 5-platform campaign averages 25-50s; we need at
-// least this much remaining budget or we ship the original with warnings.
-const RETRY_MIN_REMAINING_MS = 60_000;
+// A 5-platform Gemini call typically takes 25-50s, so on Hobby the retry
+// will only fire when the initial call came back unusually fast (~10-20s).
+// Otherwise we ship the original with `lexiconWarnings` — no timeout.
+const RETRY_MIN_REMAINING_MS = 25_000;
 
 async function generateWithLexiconGuard(
   parts: any[],

--- a/app/api/long-form/generate/route.ts
+++ b/app/api/long-form/generate/route.ts
@@ -236,7 +236,16 @@ async function runWebResearch(context: string): Promise<WebResearchBundle | null
 // Main handler
 // ---------------------------------------------------------------------------
 
+// Hard budget for the route, including the optional repair retry. Sits
+// ~10s below `maxDuration` so the function has room to persist + return.
+const LONGFORM_BUDGET_MS = 170_000;
+// Minimum runtime headroom required before we'll START a repair retry.
+// A long-form regeneration can take 30-60s; skip the retry if we don't
+// have enough budget left and ship the original with `lexiconWarnings`.
+const LONGFORM_RETRY_MIN_REMAINING_MS = 65_000;
+
 export async function POST(req: Request) {
+  const routeStartTime = Date.now();
   try {
     const cookieStore = await cookies();
 
@@ -502,9 +511,22 @@ export async function POST(req: Request) {
         (v) => v.kind === 'banned-structure' || v.kind === 'banned-contrast'
       );
 
-    if (retryWorthy) {
+    // Time-budget guard: don't start a retry that could push us past
+    // `maxDuration`. Better to ship a flagged draft with warnings than
+    // time out and ship nothing.
+    const elapsed = Date.now() - routeStartTime;
+    const remaining = LONGFORM_BUDGET_MS - elapsed;
+    const haveBudget = remaining >= LONGFORM_RETRY_MIN_REMAINING_MS;
+
+    if (retryWorthy && !haveBudget) {
+      console.warn(
+        `[LongForm][lexicon] skipping repair retry: only ${remaining}ms of budget left (need ${LONGFORM_RETRY_MIN_REMAINING_MS}ms). Returning original with ${lexiconReport.violations.length} violation(s).`
+      );
+    }
+
+    if (retryWorthy && haveBudget) {
       console.log(
-        `[LongForm][lexicon] initial article had ${lexiconReport.violations.length} violations (slop=${lexiconReport.slopScore}); retrying with repair directive`
+        `[LongForm][lexicon] initial article had ${lexiconReport.violations.length} violations (slop=${lexiconReport.slopScore}); retrying with repair directive (${remaining}ms budget remaining)`
       );
       try {
         const repairPrompt = `${prompt}\n\n${buildRepairDirective(lexiconReport)}\n\n## Rejected article (for reference only — rewrite from source, do NOT paraphrase)\n${responseText.slice(0, 6000)}`;

--- a/app/api/long-form/generate/route.ts
+++ b/app/api/long-form/generate/route.ts
@@ -1,4 +1,8 @@
-export const maxDuration = 180; // Web research + long-form generation needs more headroom
+// Vercel Hobby caps at 60s. Long-form + web research routinely runs 30-55s
+// on its own, which means the lexicon repair retry will rarely fire on Hobby
+// — we ship the original with `lexiconWarnings` instead of timing out.
+// Upgrade to Pro to raise this to 300s and let retries run reliably.
+export const maxDuration = 60;
 
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
@@ -236,13 +240,13 @@ async function runWebResearch(context: string): Promise<WebResearchBundle | null
 // Main handler
 // ---------------------------------------------------------------------------
 
-// Hard budget for the route, including the optional repair retry. Sits
-// ~10s below `maxDuration` so the function has room to persist + return.
-const LONGFORM_BUDGET_MS = 170_000;
-// Minimum runtime headroom required before we'll START a repair retry.
-// A long-form regeneration can take 30-60s; skip the retry if we don't
-// have enough budget left and ship the original with `lexiconWarnings`.
-const LONGFORM_RETRY_MIN_REMAINING_MS = 65_000;
+// Hard budget for the route, sized for Vercel Hobby's 60s function cap.
+// Leaves ~5s for DB persist + JSON return.
+const LONGFORM_BUDGET_MS = 55_000;
+// Minimum runtime headroom before we'll START a repair retry. On Hobby
+// long-form often consumes 30-55s on its own, so the retry will rarely
+// fire — we ship the original with `lexiconWarnings` instead of timing out.
+const LONGFORM_RETRY_MIN_REMAINING_MS = 30_000;
 
 export async function POST(req: Request) {
   const routeStartTime = Date.now();


### PR DESCRIPTION
- Redesigned the landing page to improve the initial user experience.
- Implemented stricter anti-AI content validation and tightened the banned lexicon.
- Extended social route timeouts and added time-budget guards to improve retry reliability.
- Adjusted maxDuration to 60 seconds and reduced budget values for Vercel Hobby tier compliance.

[v0 Session](https://v0.app/chat/pb4Gnk7rWBh)