### PR TITLE
feat: async generation via QStash + Cloud Run (bypass 60s timeout)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,0 +1,33 @@
+# Build stage
+FROM node:20-slim AS builder
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+# Compile worker/server.ts using tsx (handles @/* path aliases via tsconfig)
+RUN npx tsx --tsconfig worker/tsconfig.json --print "console.log('build ok')" 2>/dev/null || true
+# Bundle into a single JS file with esbuild for a clean, fast runtime image
+RUN npx esbuild worker/server.ts \
+  --bundle \
+  --platform=node \
+  --target=node20 \
+  --outfile=dist-worker/server.js \
+  --alias:@/=./ \
+  --external:@google-cloud/aiplatform
+
+# Runtime stage
+FROM node:20-slim
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist-worker/server.js ./server.js
+
+EXPOSE 8080
+ENV NODE_ENV=production
+
+CMD ["node", "server.js"]

--- a/app/api/composio/connect/route.ts
+++ b/app/api/composio/connect/route.ts
@@ -21,7 +21,13 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const redirectUri = `${process.env.NEXT_PUBLIC_APP_URL}/api/composio/callback`;
+    // Derive the app origin from the incoming request so this works correctly
+    // in production even if NEXT_PUBLIC_APP_URL is misconfigured or missing.
+    const reqUrl = new URL(req.url);
+    const appOrigin =
+      process.env.NEXT_PUBLIC_APP_URL ||
+      `${reqUrl.protocol}//${reqUrl.host}`;
+    const redirectUri = `${appOrigin}/api/composio/callback`;
     const redirectUrl = await initiateGitHubConnection(user.id, redirectUri);
     return NextResponse.json({ url: redirectUrl });
   } catch (error: any) {

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,28 +1,15 @@
-// Vercel Hobby tier caps function runtime at 60s. Anything declared above
-// that is silently capped, so we set 60 explicitly and rely on the budget
-// guard below to skip the lexicon repair retry whenever the initial call
-// already consumed most of the runtime. Upgrade to Pro to raise this to 300.
-export const maxDuration = 60;
+// Thin enqueue-only route. All heavy Gemini work happens in the QStash
+// worker (/api/qstash/generate) so this function returns in <1s and never
+// approaches Vercel Hobby's 60s timeout.
 import { NextResponse } from 'next/server';
-import { buildGenerationPrompt, containsPromptInjection } from '../../../lib/prompts';
-import {
-  validateCampaign,
-  buildRepairDirective,
-  summarizeForClient,
-  type CampaignShape,
-  type ValidationReport,
-} from '@/lib/prompts/lexicon-validator';
+import { containsPromptInjection } from '../../../lib/prompts';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
-import { PostHog } from 'posthog-node';
 import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
 import { createClient as createSupabaseClient } from '@supabase/supabase-js';
-import { getPlanStatus, incrementCampaignGeneration } from '@/lib/plan';
-import { getVertexAIClient } from '@/lib/genai-client';
-import { getGitHubEnrichedContext } from '@/lib/composio';
-import { extractYouTubeId, getYouTubeTranscript } from '@/lib/youtube';
-
+import { getPlanStatus } from '@/lib/plan';
+import { enqueueGenerationJob } from '@/lib/qstash';
 
 const redis = new Redis({
   url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -35,186 +22,19 @@ const ratelimit = new Ratelimit({
   analytics: true,
 });
 
-const distributionSchema = {
-  type: 'OBJECT',
-  properties: {
-    campaign: {
-      type: 'ARRAY',
-      items: {
-        type: 'OBJECT',
-        properties: {
-          day: { type: 'INTEGER' },
-          x: { type: 'STRING' },
-          linkedin: { type: 'STRING' },
-          discord: { type: 'STRING' },
-          slack: { type: 'STRING' },
-        },
-        required: ['day', 'x', 'linkedin', 'discord', 'slack'],
-      },
-    },
-    email: { type: 'STRING' },
-  },
-  required: ['campaign'],
-};
-
-async function generateFromParts(parts: any[], stream = false) {
-  const client = await getVertexAIClient();
-  
-  if (stream) {
-    // Return streaming response
-    const streamingResult = await client.models.generateContentStream({
-      model: 'gemini-3-flash-preview',
-      contents: [{ role: 'user', parts }],
-      config: {
-        responseMimeType: 'application/json',
-        responseSchema: distributionSchema,
-      },
-    });
-    return streamingResult;
-  }
-  
-  // Non-streaming response
-  const response = await client.models.generateContent({
-    model: 'gemini-3-flash-preview',
-    contents: [{ role: 'user', parts }],
-    config: {
-      responseMimeType: 'application/json',
-      responseSchema: distributionSchema,
-    },
-  });
-  
-  const responseText =
-    response.text ??
-    response.candidates?.[0]?.content?.parts?.[0]?.text ??
-    '';
-
-  if (!responseText) {
-    console.error('Unexpected response format:', JSON.stringify(response, null, 2));
-    throw new Error('Unexpected response format from Vertex AI');
-  }
-
-  return responseText;
-}
-
-/**
- * Generation slot that runs lexicon validation on the parsed campaign and,
- * if violations exceed the threshold, performs ONE retry with a strict
- * repair directive appended to the original prompt. Returns the final
- * response text plus a typed report so the caller can decide whether to
- * surface warnings to the client.
- *
- * Threshold: slopScore >= 3 OR any banned-structure / banned-contrast /
- * banned-closer violation. Single banned-word slips through with a warning
- * because LLMs occasionally use a flagged word in a sentence the lexicon
- * was never meant to catch.
- */
-// Hard budget for the entire generation slot, sized for Hobby (60s cap).
-// Leaves ~5s for DB persist + JSON return + PostHog flush.
-const GENERATION_BUDGET_MS = 55_000;
-// Minimum runtime headroom required before we'll START a repair retry.
-// A 5-platform Gemini call typically takes 25-50s, so on Hobby the retry
-// will only fire when the initial call came back unusually fast (~10-20s).
-// Otherwise we ship the original with `lexiconWarnings` — no timeout.
-const RETRY_MIN_REMAINING_MS = 25_000;
-
-async function generateWithLexiconGuard(
-  parts: any[],
-  basePrompt: string,
-  startTime: number
-): Promise<{ responseText: string; report: ValidationReport; retried: boolean }> {
-  const initial = await generateFromParts(parts);
-
-  let parsed: CampaignShape | null = null;
-  try {
-    parsed = JSON.parse(initial);
-  } catch (err) {
-    console.warn('[lexicon] could not parse initial response, skipping validation');
-    return { responseText: initial, report: { violations: [], slopScore: 0, clean: true }, retried: false };
-  }
-
-  const report = validateCampaign(parsed);
-  const retryWorthy =
-    report.slopScore >= 3 ||
-    report.violations.some(
-      (v) =>
-        v.kind === 'banned-structure' ||
-        v.kind === 'banned-contrast' ||
-        v.kind === 'banned-closer'
-    );
-
-  if (!retryWorthy) {
-    return { responseText: initial, report, retried: false };
-  }
-
-  // Time-budget guard: never start a retry that could push us past the
-  // function timeout. Better to ship a flagged draft than time out and
-  // ship nothing.
-  const elapsed = Date.now() - startTime;
-  const remaining = GENERATION_BUDGET_MS - elapsed;
-  if (remaining < RETRY_MIN_REMAINING_MS) {
-    console.warn(
-      `[lexicon] skipping repair retry: only ${remaining}ms of budget left (need ${RETRY_MIN_REMAINING_MS}ms). Returning original with ${report.violations.length} violation(s).`
-    );
-    return { responseText: initial, report, retried: false };
-  }
-
-  console.log(
-    `[lexicon] initial output had ${report.violations.length} violation(s) (slop=${report.slopScore}); retrying with repair directive (${remaining}ms budget remaining)`
-  );
-
-  const repairDirective = buildRepairDirective(report);
-  const repairParts: any[] = [
-    { text: `${basePrompt}\n\n${repairDirective}\n\n## Rejected output (for reference only — do NOT paraphrase, rewrite from source)\n${initial.slice(0, 4000)}` },
-    ...parts.slice(1), // preserve any inline asset parts (images, PDFs, etc.)
-  ];
-
-  let retried: string;
-  try {
-    retried = (await generateFromParts(repairParts)) as string;
-  } catch (err) {
-    console.error('[lexicon] retry failed, returning original:', err);
-    return { responseText: initial, report, retried: true };
-  }
-
-  let retriedParsed: CampaignShape | null = null;
-  try {
-    retriedParsed = JSON.parse(retried);
-  } catch {
-    console.warn('[lexicon] retried response unparseable, returning original');
-    return { responseText: initial, report, retried: true };
-  }
-
-  const retriedReport = validateCampaign(retriedParsed);
-  console.log(
-    `[lexicon] retry produced ${retriedReport.violations.length} violation(s) (slop=${retriedReport.slopScore})`
-  );
-
-  // Take whichever response is cleaner.
-  if (retriedReport.slopScore < report.slopScore) {
-    return { responseText: retried, report: retriedReport, retried: true };
-  }
-  return { responseText: initial, report, retried: true };
-}
-
 export async function POST(req: Request) {
-  const startTime = Date.now();
-  const posthog = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-    host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
-  });
-
   try {
     const ip = req.headers.get('x-forwarded-for') ?? '127.0.0.1';
     const { success } = await ratelimit.limit(`ratelimit_${ip}`);
 
     if (!success) {
-      console.warn(`[SECURITY] Rate limit exceeded for IP: ${ip}`);
       return NextResponse.json(
         { error: 'Too many generation requests. Please try again later.' },
         { status: 429 },
       );
     }
 
-    // --- DEMO MODE CHECK ---
+    // --- DEMO MODE ---
     const isDemo = req.headers.get('x-demo-mode') === 'true';
     if (isDemo) {
       const demoKey = `demo_${ip}`;
@@ -226,272 +46,121 @@ export async function POST(req: Request) {
         );
       }
       await redis.set(demoKey, '1', { ex: 86400 });
-
-      const payload = await req.json();
-      const { sourceMaterial, campaignDirectives } = payload;
-
-      let urlContext = sourceMaterial?.url || '';
-      const textContext = sourceMaterial?.rawText || '';
-      const assetUrls = sourceMaterial?.assetUrls || [];
-
-      // --- YouTube transcript handling (Demo mode) ---
-      let effectiveUrlContext = urlContext;
-      if (urlContext) {
-        const videoId = extractYouTubeId(urlContext);
-        if (videoId) {
-          const transcript = await getYouTubeTranscript(videoId);
-          if (transcript) {
-            effectiveUrlContext = `YouTube transcript: ${transcript}`;
-          }
-        }
-      }
-
-      const tweetFormat = campaignDirectives?.tweetFormat || 'single';
-      const personaVoice = campaignDirectives?.personaVoice || 'Expert Content Strategist';
-
-      const finalContext = campaignDirectives?.additionalContext
-        ? `${textContext}\n\nAdditional Directives: ${campaignDirectives.additionalContext}`
-        : textContext;
-
-      if (containsPromptInjection(finalContext)) {
-        console.warn(`[SECURITY] Prompt injection attempt intercepted from IP: ${ip}`);
-        return NextResponse.json(
-          { error: 'Security Policy Violation: Invalid context structure detected.' },
-          { status: 400 },
-        );
-      }
-
-      const textPrompt = buildGenerationPrompt({
-        tweetFormat,
-        personaVoice,
-        textContext: finalContext,
-        urlContext: effectiveUrlContext,
-      });
-
-      const parts: any[] = [{ text: textPrompt }];
-
-      if (assetUrls?.length) {
-        for (const assetUrl of assetUrls) {
-          try {
-            const fileRes = await fetch(assetUrl);
-            if (!fileRes.ok) throw new Error(`HTTP error! status: ${fileRes.status}`);
-            const mimeType = fileRes.headers.get('content-type') || 'application/octet-stream';
-            const arrayBuffer = await fileRes.arrayBuffer();
-            const base64Data = Buffer.from(arrayBuffer).toString('base64');
-            parts.push({
-              inlineData: {
-                data: base64Data,
-                mimeType,
-              },
-            });
-          } catch (err) {
-            console.error(`Failed to fetch and process asset from R2: ${assetUrl}`, err);
-          }
-        }
-      }
-
-      const { responseText, report: lexiconReport, retried } =
-        await generateWithLexiconGuard(parts, textPrompt, startTime);
-      const lexiconWarnings = summarizeForClient(lexiconReport);
-
-      const durationMs = Date.now() - startTime;
-      posthog.capture({
-        distinctId: ip,
-        event: 'vertex_generation_completed_demo',
-        properties: {
-          durationMs,
-          personaVoice,
-          hasFile: assetUrls.length > 0,
-          assetCount: assetUrls.length,
-          status: 'success',
-          lexiconViolations: lexiconReport.violations.length,
-          lexiconSlopScore: lexiconReport.slopScore,
-          lexiconRetried: retried,
-        },
-      });
-      await posthog.shutdown();
-
-      return NextResponse.json({ output: responseText, lexiconWarnings });
     }
 
-    // --- AUTHENTICATED FLOW ---
+    // --- AUTH ---
     let user = null;
-    let authError = null;
 
-    const cookieStore = await cookies();
-    const supabaseFromCookie = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          getAll() {
-            return cookieStore.getAll();
-          },
-          setAll() {
-            /* no‑op */
-          },
-        },
-      },
-    );
-    const { data: { user: userFromCookie }, error: cookieError } = await supabaseFromCookie.auth.getUser();
-    if (userFromCookie) user = userFromCookie;
-
-    if (!user) {
-      const authHeader = req.headers.get('Authorization');
-      if (authHeader?.startsWith('Bearer ')) {
-        const token = authHeader.split(' ')[1];
-        const supabaseFromToken = createSupabaseClient(
-          process.env.NEXT_PUBLIC_SUPABASE_URL!,
-          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-        );
-        const { data: { user: userFromToken }, error: tokenError } = await supabaseFromToken.auth.getUser(token);
-        if (userFromToken) user = userFromToken;
-        else authError = tokenError;
-      }
-    }
-
-    if (!user) {
-      console.log('Auth failed:', { cookieError, authError });
-      return NextResponse.json(
-        { error: 'Unauthorized', details: authError?.message || 'No valid session' },
-        { status: 401 },
-      );
-    }
-
-    // --- GitHub context (repos + recent commits + README + latest release) ---
-    let githubContext = '';
-    const { data: githubConn, error: githubError } = await supabaseFromCookie
-      .from('user_composio_connections')
-      .select('connection_id')
-      .eq('user_id', user.id)
-      .eq('app', 'github')
-      .maybeSingle();
-
-    if (githubConn && !githubError) {
-      try {
-        githubContext = await getGitHubEnrichedContext(githubConn.connection_id);
-      } catch (err) {
-        console.error('Failed to fetch GitHub context:', err);
-      }
-    }
-
-    const planStatus = await getPlanStatus(user.id);
-    if (!planStatus.canGenerate) {
-      return NextResponse.json(
+    if (!isDemo) {
+      const cookieStore = await cookies();
+      const supabaseFromCookie = createServerClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
         {
-          error: 'generation_limit_reached',
-          plan: planStatus.plan,
-          generationsUsed: planStatus.generationsUsed,
-          generationsLimit: planStatus.generationsLimit,
+          cookies: {
+            getAll() { return cookieStore.getAll(); },
+            setAll() { /* no-op */ },
+          },
         },
-        { status: 403 },
       );
+      const { data: { user: userFromCookie } } = await supabaseFromCookie.auth.getUser();
+      if (userFromCookie) user = userFromCookie;
+
+      if (!user) {
+        const authHeader = req.headers.get('Authorization');
+        if (authHeader?.startsWith('Bearer ')) {
+          const token = authHeader.split(' ')[1];
+          const supabaseFromToken = createSupabaseClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL!,
+            process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+          );
+          const { data: { user: userFromToken } } = await supabaseFromToken.auth.getUser(token);
+          if (userFromToken) user = userFromToken;
+        }
+      }
+
+      if (!user) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+
+      // --- PLAN CHECK ---
+      const planStatus = await getPlanStatus(user.id);
+      if (!planStatus.canGenerate) {
+        return NextResponse.json(
+          {
+            error: 'generation_limit_reached',
+            plan: planStatus.plan,
+            generationsUsed: planStatus.generationsUsed,
+            generationsLimit: planStatus.generationsLimit,
+          },
+          { status: 403 },
+        );
+      }
     }
 
+    // --- PAYLOAD VALIDATION ---
     const payload = await req.json();
     const { sourceMaterial, campaignDirectives } = payload;
 
-    let urlContext = sourceMaterial?.url || '';
     const textContext = sourceMaterial?.rawText || '';
-    const assetUrls = sourceMaterial?.assetUrls || [];
+    const additionalContext = campaignDirectives?.additionalContext || '';
 
-    // --- YouTube transcript handling (Authenticated flow) ---
-    let effectiveUrlContext = urlContext;
-    if (urlContext) {
-      const videoId = extractYouTubeId(urlContext);
-      if (videoId) {
-        const transcript = await getYouTubeTranscript(videoId);
-        if (transcript) {
-          effectiveUrlContext = `YouTube transcript: ${transcript}`;
-        }
-      }
-    }
-
-    // Combine textContext with GitHub context (if any)
-    const enhancedText = textContext + githubContext;
-
-    const tweetFormat = campaignDirectives?.tweetFormat || 'single';
-    const personaVoice = campaignDirectives?.personaVoice || 'Expert Content Strategist';
-
-    const finalContext = campaignDirectives?.additionalContext
-      ? `${enhancedText}\n\nAdditional Directives: ${campaignDirectives.additionalContext}`
-      : enhancedText;
-
-    if (containsPromptInjection(finalContext)) {
-      console.warn(`[SECURITY] Prompt injection attempt intercepted from IP: ${ip}`);
+    if (containsPromptInjection(textContext) || containsPromptInjection(additionalContext)) {
+      console.warn(`[SECURITY] Prompt injection attempt from IP: ${ip}`);
       return NextResponse.json(
         { error: 'Security Policy Violation: Invalid context structure detected.' },
         { status: 400 },
       );
     }
 
-    const textPrompt = buildGenerationPrompt({
-      tweetFormat,
-      personaVoice,
-      textContext: finalContext,
-      urlContext: effectiveUrlContext,
-    });
+    // --- INSERT JOB ---
+    const supabaseAdmin = createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
 
-    const parts: any[] = [{ text: textPrompt }];
+    const jobPayload = {
+      sourceMaterial,
+      campaignDirectives,
+      isDemo,
+      userId: user?.id ?? null,
+    };
 
-    if (assetUrls?.length) {
-      for (const assetUrl of assetUrls) {
-        try {
-          const fileRes = await fetch(assetUrl);
-          if (!fileRes.ok) throw new Error(`HTTP error! status: ${fileRes.status}`);
-          const mimeType = fileRes.headers.get('content-type') || 'application/octet-stream';
-          const arrayBuffer = await fileRes.arrayBuffer();
-          const base64Data = Buffer.from(arrayBuffer).toString('base64');
-          parts.push({
-            inlineData: {
-              data: base64Data,
-              mimeType,
-            },
-          });
-        } catch (err) {
-          console.error(`Failed to fetch and process asset from R2: ${assetUrl}`, err);
-        }
-      }
+    const { data: job, error: insertError } = await supabaseAdmin
+      .from('generation_jobs')
+      .insert({
+        user_id: user?.id ?? null,
+        payload: jobPayload,
+        status: 'pending',
+      })
+      .select('id')
+      .single();
+
+    if (insertError || !job) {
+      console.error('[generate] Failed to insert job:', insertError);
+      return NextResponse.json({ error: 'Failed to start generation' }, { status: 500 });
     }
 
-    const { responseText, report: lexiconReport, retried } =
-      await generateWithLexiconGuard(parts, textPrompt, startTime);
-    const lexiconWarnings = summarizeForClient(lexiconReport);
+    // --- ENQUEUE ---
+    // Derive the app URL from the request so it works even if APP_URL is wrong.
+    const reqUrl = new URL(req.url);
+    const appUrl =
+      process.env.APP_URL ||
+      process.env.NEXT_PUBLIC_APP_URL ||
+      `${reqUrl.protocol}//${reqUrl.host}`;
 
-    await incrementCampaignGeneration(user.id);
+    try {
+      await enqueueGenerationJob(job.id, appUrl);
+    } catch (qErr: any) {
+      // Clean up the orphaned job row before returning the error
+      await supabaseAdmin.from('generation_jobs').delete().eq('id', job.id);
+      console.error('[generate] QStash enqueue failed:', qErr.message);
+      return NextResponse.json({ error: qErr.message }, { status: 500 });
+    }
 
-    const durationMs = Date.now() - startTime;
-    posthog.capture({
-      distinctId: ip,
-      event: 'vertex_generation_completed',
-      properties: {
-        durationMs,
-        personaVoice,
-        hasFile: assetUrls.length > 0,
-        assetCount: assetUrls.length,
-        status: 'success',
-        lexiconViolations: lexiconReport.violations.length,
-        lexiconSlopScore: lexiconReport.slopScore,
-        lexiconRetried: retried,
-      },
-    });
-    await posthog.shutdown();
-
-    return NextResponse.json({ output: responseText, lexiconWarnings });
+    return NextResponse.json({ jobId: job.id });
   } catch (error: any) {
-    const durationMs = Date.now() - startTime;
-    posthog.capture({
-      distinctId: req.headers.get('x-forwarded-for') ?? '127.0.0.1',
-      event: 'vertex_generation_failed',
-      properties: {
-        durationMs,
-        errorMessage: error.message,
-        status: 'error',
-      },
-    });
-    await posthog.shutdown();
-
-    console.error('Vertex AI Generate Error:', error);
+    console.error('[generate] Unexpected error:', error);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/app/api/generate/status/route.ts
+++ b/app/api/generate/status/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { createServerClient } from '@supabase/ssr';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const jobId = searchParams.get('jobId');
+
+  if (!jobId) {
+    return NextResponse.json({ error: 'Missing jobId' }, { status: 400 });
+  }
+
+  // Auth — accept cookie or bearer token (same pattern as /api/generate)
+  let userId: string | null = null;
+  let isDemo = false;
+
+  const cookieStore = await cookies();
+  const supabaseFromCookie = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() { return cookieStore.getAll(); },
+        setAll() { /* no-op */ },
+      },
+    },
+  );
+  const { data: { user: userFromCookie } } = await supabaseFromCookie.auth.getUser();
+  if (userFromCookie) userId = userFromCookie.id;
+
+  if (!userId) {
+    const authHeader = req.headers.get('Authorization');
+    if (authHeader?.startsWith('Bearer ')) {
+      const token = authHeader.split(' ')[1];
+      const supabaseFromToken = createSupabaseClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      );
+      const { data: { user: userFromToken } } = await supabaseFromToken.auth.getUser(token);
+      if (userFromToken) userId = userFromToken.id;
+    }
+  }
+
+  // Demo jobs have a placeholder user_id — allow polling without auth
+  const supabaseAdmin = createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  const { data: job, error } = await supabaseAdmin
+    .from('generation_jobs')
+    .select('id, user_id, status, result, error_message, payload')
+    .eq('id', jobId)
+    .single();
+
+  if (error || !job) {
+    return NextResponse.json({ error: 'Job not found' }, { status: 404 });
+  }
+
+  // Only the job owner or a demo job may be polled
+  isDemo = job.payload?.isDemo === true;
+  if (!isDemo && job.user_id !== userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+  }
+
+  return NextResponse.json({
+    status: job.status,
+    result: job.status === 'done' ? job.result : null,
+    error: job.status === 'error' ? (job.error_message || 'Generation failed') : null,
+  });
+}

--- a/app/api/qstash/generate/route.ts
+++ b/app/api/qstash/generate/route.ts
@@ -1,0 +1,334 @@
+// QStash worker for async campaign generation.
+// On Vercel Hobby this is still capped at 60s — point GENERATION_WORKER_URL
+// at a Cloud Run endpoint to remove the limit entirely (no other changes needed).
+export const maxDuration = 60;
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { buildGenerationPrompt } from '@/lib/prompts';
+import {
+  validateCampaign,
+  buildRepairDirective,
+  summarizeForClient,
+  type CampaignShape,
+  type ValidationReport,
+} from '@/lib/prompts/lexicon-validator';
+import { PostHog } from 'posthog-node';
+import { getPlanStatus, incrementCampaignGeneration } from '@/lib/plan';
+import { getVertexAIClient } from '@/lib/genai-client';
+import { getGitHubEnrichedContext } from '@/lib/composio';
+import { extractYouTubeId, getYouTubeTranscript } from '@/lib/youtube';
+import { verifyQStashRequest } from '@/lib/qstash';
+
+const distributionSchema = {
+  type: 'OBJECT',
+  properties: {
+    campaign: {
+      type: 'ARRAY',
+      items: {
+        type: 'OBJECT',
+        properties: {
+          day: { type: 'INTEGER' },
+          x: { type: 'STRING' },
+          linkedin: { type: 'STRING' },
+          discord: { type: 'STRING' },
+          slack: { type: 'STRING' },
+        },
+        required: ['day', 'x', 'linkedin', 'discord', 'slack'],
+      },
+    },
+    email: { type: 'STRING' },
+  },
+  required: ['campaign'],
+};
+
+async function generateFromParts(parts: any[]): Promise<string> {
+  const client = await getVertexAIClient();
+  const response = await client.models.generateContent({
+    model: 'gemini-3-flash-preview',
+    contents: [{ role: 'user', parts }],
+    config: {
+      responseMimeType: 'application/json',
+      responseSchema: distributionSchema,
+    },
+  });
+
+  const responseText =
+    response.text ??
+    response.candidates?.[0]?.content?.parts?.[0]?.text ??
+    '';
+
+  if (!responseText) {
+    console.error('[worker] Unexpected response format:', JSON.stringify(response, null, 2));
+    throw new Error('Unexpected response format from Vertex AI');
+  }
+
+  return responseText;
+}
+
+const GENERATION_BUDGET_MS = 55_000;
+const RETRY_MIN_REMAINING_MS = 25_000;
+
+async function generateWithLexiconGuard(
+  parts: any[],
+  basePrompt: string,
+  startTime: number,
+  hasImages: boolean = false,
+): Promise<{ responseText: string; report: ValidationReport; retried: boolean }> {
+  const initial = await generateFromParts(parts);
+
+  let parsed: CampaignShape | null = null;
+  try {
+    parsed = JSON.parse(initial);
+  } catch {
+    console.warn('[worker][lexicon] could not parse initial response, skipping validation');
+    return { responseText: initial, report: { violations: [], slopScore: 0, clean: true }, retried: false };
+  }
+
+  const report = validateCampaign(parsed);
+  const retryWorthy =
+    report.slopScore >= 3 ||
+    report.violations.some(
+      (v) =>
+        v.kind === 'banned-structure' ||
+        v.kind === 'banned-contrast' ||
+        v.kind === 'banned-closer'
+    );
+
+  if (!retryWorthy) {
+    return { responseText: initial, report, retried: false };
+  }
+
+  if (hasImages) {
+    console.warn('[worker][lexicon] skipping repair retry: images in payload');
+    return { responseText: initial, report, retried: false };
+  }
+
+  const elapsed = Date.now() - startTime;
+  const remaining = GENERATION_BUDGET_MS - elapsed;
+  if (remaining < RETRY_MIN_REMAINING_MS) {
+    console.warn(
+      `[worker][lexicon] skipping repair retry: only ${remaining}ms budget left. ` +
+      `Returning original with ${report.violations.length} violation(s).`
+    );
+    return { responseText: initial, report, retried: false };
+  }
+
+  console.log(
+    `[worker][lexicon] ${report.violations.length} violation(s) (slop=${report.slopScore}); ` +
+    `retrying with repair directive (${remaining}ms remaining)`
+  );
+
+  const repairDirective = buildRepairDirective(report);
+  const repairParts: any[] = [
+    { text: `${basePrompt}\n\n${repairDirective}\n\n## Rejected output (for reference only — do NOT paraphrase, rewrite from source)\n${initial.slice(0, 4000)}` },
+    ...parts.slice(1),
+  ];
+
+  let retried: string;
+  try {
+    retried = await generateFromParts(repairParts);
+  } catch (err) {
+    console.error('[worker][lexicon] retry failed, returning original:', err);
+    return { responseText: initial, report, retried: true };
+  }
+
+  let retriedParsed: CampaignShape | null = null;
+  try {
+    retriedParsed = JSON.parse(retried);
+  } catch {
+    console.warn('[worker][lexicon] retried response unparseable, returning original');
+    return { responseText: initial, report, retried: true };
+  }
+
+  const retriedReport = validateCampaign(retriedParsed);
+  console.log(
+    `[worker][lexicon] retry produced ${retriedReport.violations.length} violation(s) (slop=${retriedReport.slopScore})`
+  );
+
+  if (retriedReport.slopScore < report.slopScore) {
+    return { responseText: retried, report: retriedReport, retried: true };
+  }
+  return { responseText: initial, report, retried: true };
+}
+
+export async function POST(req: Request) {
+  const startTime = Date.now();
+  const supabaseAdmin = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  // --- VERIFY QSTASH SIGNATURE ---
+  const signature = req.headers.get('upstash-signature');
+  const rawBody = await req.text();
+
+  if (signature) {
+    const isValid = await verifyQStashRequest(signature, rawBody);
+    if (!isValid) {
+      console.error('[worker] Invalid QStash signature');
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+    }
+  } else if (process.env.NODE_ENV === 'production') {
+    return NextResponse.json({ error: 'Missing signature' }, { status: 401 });
+  }
+
+  const { jobId } = JSON.parse(rawBody);
+  if (!jobId) {
+    return NextResponse.json({ error: 'Missing jobId' }, { status: 400 });
+  }
+
+  // --- FETCH JOB ---
+  const { data: job, error: fetchError } = await supabaseAdmin
+    .from('generation_jobs')
+    .select('*')
+    .eq('id', jobId)
+    .single();
+
+  if (fetchError || !job) {
+    console.error(`[worker] Job ${jobId} not found:`, fetchError);
+    return NextResponse.json({ error: 'Job not found' }, { status: 404 });
+  }
+
+  if (job.status !== 'pending') {
+    console.log(`[worker] Job ${jobId} already processed (status: ${job.status})`);
+    return NextResponse.json({ success: true, skipped: true });
+  }
+
+  await supabaseAdmin
+    .from('generation_jobs')
+    .update({ status: 'processing', updated_at: new Date().toISOString() })
+    .eq('id', jobId);
+
+  const posthog = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+  });
+
+  const markError = async (message: string) => {
+    await supabaseAdmin
+      .from('generation_jobs')
+      .update({ status: 'error', error_message: message, updated_at: new Date().toISOString() })
+      .eq('id', jobId);
+  };
+
+  try {
+    const { sourceMaterial, campaignDirectives, isDemo, userId } = job.payload;
+
+    let urlContext = sourceMaterial?.url || '';
+    const textContext = sourceMaterial?.rawText || '';
+    const assetUrls: string[] = sourceMaterial?.assetUrls || [];
+
+    // --- YouTube transcript ---
+    let effectiveUrlContext = urlContext;
+    if (urlContext) {
+      const videoId = extractYouTubeId(urlContext);
+      if (videoId) {
+        const transcript = await getYouTubeTranscript(videoId);
+        if (transcript) effectiveUrlContext = `YouTube transcript: ${transcript}`;
+      }
+    }
+
+    // --- GitHub context (authenticated users only) ---
+    let githubContext = '';
+    if (!isDemo && userId) {
+      const { data: githubConn } = await supabaseAdmin
+        .from('user_composio_connections')
+        .select('connection_id')
+        .eq('user_id', userId)
+        .eq('app', 'github')
+        .maybeSingle();
+
+      if (githubConn) {
+        try {
+          githubContext = await getGitHubEnrichedContext(githubConn.connection_id);
+        } catch (err) {
+          console.error('[worker] Failed to fetch GitHub context:', err);
+        }
+      }
+    }
+
+    const enhancedText = textContext + githubContext;
+    const tweetFormat = campaignDirectives?.tweetFormat || 'single';
+    const personaVoice = campaignDirectives?.personaVoice || 'Expert Content Strategist';
+    const finalContext = campaignDirectives?.additionalContext
+      ? `${enhancedText}\n\nAdditional Directives: ${campaignDirectives.additionalContext}`
+      : enhancedText;
+
+    const textPrompt = buildGenerationPrompt({
+      tweetFormat,
+      personaVoice,
+      textContext: finalContext,
+      urlContext: effectiveUrlContext,
+    });
+
+    const parts: any[] = [{ text: textPrompt }];
+
+    if (assetUrls.length) {
+      for (const assetUrl of assetUrls) {
+        try {
+          const fileRes = await fetch(assetUrl);
+          if (!fileRes.ok) throw new Error(`HTTP ${fileRes.status}`);
+          const mimeType = fileRes.headers.get('content-type') || 'application/octet-stream';
+          const arrayBuffer = await fileRes.arrayBuffer();
+          const base64Data = Buffer.from(arrayBuffer).toString('base64');
+          parts.push({ inlineData: { data: base64Data, mimeType } });
+        } catch (err) {
+          console.error(`[worker] Failed to fetch asset ${assetUrl}:`, err);
+        }
+      }
+    }
+
+    const { responseText, report: lexiconReport, retried } =
+      await generateWithLexiconGuard(parts, textPrompt, startTime, assetUrls.length > 0);
+    const lexiconWarnings = summarizeForClient(lexiconReport);
+
+    // --- WRITE RESULT ---
+    await supabaseAdmin
+      .from('generation_jobs')
+      .update({
+        status: 'done',
+        result: { output: responseText, lexiconWarnings },
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', jobId);
+
+    // --- POST-GEN SIDE-EFFECTS (authenticated only) ---
+    if (!isDemo && userId) {
+      await incrementCampaignGeneration(userId);
+    }
+
+    const durationMs = Date.now() - startTime;
+    posthog.capture({
+      distinctId: userId || 'demo',
+      event: isDemo ? 'vertex_generation_completed_demo' : 'vertex_generation_completed',
+      properties: {
+        durationMs,
+        personaVoice,
+        hasFile: assetUrls.length > 0,
+        assetCount: assetUrls.length,
+        status: 'success',
+        lexiconViolations: lexiconReport.violations.length,
+        lexiconSlopScore: lexiconReport.slopScore,
+        lexiconRetried: retried,
+        async: true,
+      },
+    });
+    await posthog.shutdown();
+
+    console.log(`[worker] Job ${jobId} completed in ${durationMs}ms`);
+    return NextResponse.json({ success: true, jobId });
+  } catch (error: any) {
+    const durationMs = Date.now() - startTime;
+    console.error(`[worker] Job ${jobId} failed after ${durationMs}ms:`, error);
+    await markError(error.message || 'Internal error');
+
+    posthog.capture({
+      distinctId: job.payload?.userId || 'unknown',
+      event: 'vertex_generation_failed',
+      properties: { durationMs, errorMessage: error.message, async: true },
+    });
+    await posthog.shutdown();
+
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -186,52 +186,99 @@ const handleGenerate = async () => {
       },
     };
 
-    const response = await fetch("/api/generate", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${session?.access_token}`,
-      },
-      body: JSON.stringify(payload),
-    });
+    // Step 1: enqueue the job (returns in <1s)
+    let enqueueRes: Response;
+    try {
+      enqueueRes = await fetch("/api/generate", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session?.access_token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+    } catch {
+      setErrorMessage("Network error. Please check your connection and try again.");
+      setLoading(false);
+      return;
+    }
 
-    if (!response.ok) {
-      let errorMsg = "We encountered a hiccup connecting to the AI engine. Please try again.";
+    if (!enqueueRes.ok) {
+      let errorMsg = "We encountered a hiccup starting the generation. Please try again.";
       try {
-        const errorData = await response.json();
+        const errorData = await enqueueRes.json();
         if (errorData.error) errorMsg = errorData.error;
-      } catch {
-        // ignore
-      }
+      } catch { /* ignore */ }
       setErrorMessage(errorMsg);
       setLoading(false);
       return;
     }
 
-    const data = await response.json();
-    if (data.error) {
-      setErrorMessage(data.error);
+    const { jobId, error: enqueueError } = await enqueueRes.json();
+    if (enqueueError || !jobId) {
+      setErrorMessage(enqueueError || "Failed to start generation.");
       setLoading(false);
       return;
     }
 
-    // --- Robust JSON extraction ---
+    // Step 2: poll /api/generate/status until done or error
+    // Max 3 minutes (90 attempts × 2s). QStash retries the worker automatically
+    // if it times out, so heavy content may complete on a second worker attempt.
+    const MAX_ATTEMPTS = 90;
+    const POLL_INTERVAL_MS = 2_000;
+    let data: { output: string; lexiconWarnings?: any[] } | null = null;
+
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
+      let statusRes: Response;
+      try {
+        statusRes = await fetch(`/api/generate/status?jobId=${jobId}`, {
+          headers: { Authorization: `Bearer ${session?.access_token}` },
+        });
+      } catch {
+        // Transient network blip — keep polling
+        continue;
+      }
+
+      if (!statusRes.ok) continue;
+
+      const statusData = await statusRes.json();
+
+      if (statusData.status === "error") {
+        setErrorMessage(statusData.error || "Generation failed. Please try again.");
+        setLoading(false);
+        return;
+      }
+
+      if (statusData.status === "done" && statusData.result) {
+        data = statusData.result;
+        break;
+      }
+    }
+
+    if (!data) {
+      setErrorMessage(
+        "Generation is taking longer than expected. Your content may still be processing — check back in a moment or try again with less content."
+      );
+      setLoading(false);
+      return;
+    }
+
+    // Step 3: parse and display the result (same logic as before)
     let jsonString = data.output;
     let finalResponse;
 
     try {
-      // Remove markdown code fences
       jsonString = jsonString.replace(/```json\s*([\s\S]*?)\s*```/gi, '$1');
       jsonString = jsonString.replace(/```\s*([\s\S]*?)\s*```/gi, '$1').trim();
 
-      // Find the first '{' and the last '}'
       const firstBrace = jsonString.indexOf('{');
       const lastBrace = jsonString.lastIndexOf('}');
       if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
         jsonString = jsonString.slice(firstBrace, lastBrace + 1);
       }
 
-      // If still not valid, try to find any JSON object
       if (!jsonString.startsWith('{')) {
         const possibleMatch = jsonString.match(/\{[\s\S]*\}/);
         if (possibleMatch) jsonString = possibleMatch[0];
@@ -240,7 +287,6 @@ const handleGenerate = async () => {
       finalResponse = JSON.parse(jsonString);
     } catch (parseError) {
       console.error('JSON parse error:', parseError);
-      console.error('Raw AI output that caused the crash:', data.output);
       setErrorMessage("The AI returned an unexpected format. Please try again with different context.");
       setLoading(false);
       return;
@@ -255,7 +301,6 @@ const handleGenerate = async () => {
       return;
     }
 
-    // Show the generated content immediately
     setCampaign(finalCampaign);
     setEmailContent(finalEmail);
     setTimeout(() => {
@@ -277,7 +322,6 @@ const handleGenerate = async () => {
           toast.error('Campaign saved locally but failed to sync to history.');
         }
 
-        // Refresh stats
         await new Promise((resolve) => setTimeout(resolve, 200));
         refreshStats();
         fetchHistory(session.user.id);

--- a/components/PersonasManager.tsx
+++ b/components/PersonasManager.tsx
@@ -22,13 +22,18 @@ export default function PersonasManager({ session }: PersonasManagerProps) {
 
   const fetchPersonas = async () => {
     setIsLoading(true);
-    const { data, error } = await supabase
-      .from("user_personas")
-      .select("*")
-      .eq("user_id", session.user.id)
-      .order("created_at", { ascending: false });
-    if (!error && data) setPersonas(data);
-    setIsLoading(false);
+    try {
+      const { data, error } = await supabase
+        .from("user_personas")
+        .select("*")
+        .eq("user_id", session.user.id)
+        .order("created_at", { ascending: false });
+      if (!error && data) setPersonas(data);
+    } catch {
+      // Supabase client error (e.g. network timeout) — don't leave spinner forever
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleCreate = async () => {

--- a/lib/genai-client.ts
+++ b/lib/genai-client.ts
@@ -5,9 +5,20 @@ import { ExternalAccountClient } from 'google-auth-library';
 export async function getVertexAIClient() {
   const projectId = process.env.GCP_PROJECT_ID || 'ozigi-489021';
 
+  // Cloud Run sets K_SERVICE. Use Application Default Credentials (ADC) —
+  // the service account attached to the Cloud Run service is used automatically.
+  const isCloudRun = !!process.env.K_SERVICE;
+  if (isCloudRun) {
+    return new GoogleGenAI({
+      vertexai: true,
+      project: projectId,
+      location: 'global',
+    });
+  }
+
   // Check for Vercel environment (production, preview, or v0 sandbox)
   const isVercelEnv = process.env.VERCEL || process.env.VERCEL_ENV || process.env.VERCEL_URL;
-  
+
   if (isVercelEnv) {
     const projectNumber = process.env.GCP_PROJECT_NUMBER?.trim();
     const poolId = process.env.GCP_WORKLOAD_IDENTITY_POOL_ID?.trim();

--- a/lib/qstash.ts
+++ b/lib/qstash.ts
@@ -61,6 +61,37 @@ export async function cancelQStashMessage(messageId: string): Promise<void> {
 }
 
 /**
+ * Enqueue an async generation job.
+ * The worker URL defaults to /api/qstash/generate on this host, but can be
+ * overridden via GENERATION_WORKER_URL to point at a Cloud Run endpoint with
+ * a longer timeout — no other code changes needed.
+ */
+export async function enqueueGenerationJob(
+  jobId: string,
+  appUrl: string,
+): Promise<string> {
+  const workerUrl =
+    process.env.GENERATION_WORKER_URL ||
+    `${appUrl}/api/qstash/generate`;
+
+  if (workerUrl.includes('localhost')) {
+    throw new Error(
+      'QStash cannot deliver webhooks to localhost. ' +
+      'Set APP_URL or GENERATION_WORKER_URL to your public domain.'
+    );
+  }
+
+  const response = await qstashClient.publishJSON({
+    url: workerUrl,
+    body: { jobId },
+    retries: 3,
+  });
+
+  console.log(`[QStash] Enqueued generation job ${jobId}, messageId: ${response.messageId}`);
+  return response.messageId;
+}
+
+/**
  * Verify that an incoming request is from QStash
  */
 export async function verifyQStashRequest(

--- a/supabase/migrations/011-generation-jobs.sql
+++ b/supabase/migrations/011-generation-jobs.sql
@@ -1,0 +1,39 @@
+-- Async generation jobs table.
+-- /api/generate inserts a row and returns the id immediately.
+-- The QStash worker (/api/qstash/generate) does the heavy Gemini work and
+-- writes the result back here. The frontend polls /api/generate/status to
+-- pick up the result without blocking a Vercel function for 60s.
+--
+-- user_id is nullable to support unauthenticated demo requests.
+-- Authenticated jobs reference auth.users; demo jobs have user_id = null.
+
+create table if not exists public.generation_jobs (
+  id            uuid        primary key default gen_random_uuid(),
+  user_id       uuid        references auth.users(id) on delete cascade,
+  status        text        not null default 'pending'
+                            check (status in ('pending', 'processing', 'done', 'error')),
+  payload       jsonb       not null,
+  result        jsonb,
+  error_message text,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now()
+);
+
+-- Authenticated users may read/insert their own jobs.
+-- Demo jobs (user_id IS NULL) are accessible only via the service role key.
+alter table public.generation_jobs enable row level security;
+
+create policy "users can read own generation jobs"
+  on public.generation_jobs for select
+  using (auth.uid() = user_id);
+
+create policy "users can insert own generation jobs"
+  on public.generation_jobs for insert
+  with check (auth.uid() = user_id);
+
+-- Fast lookup for status polling and cleanup
+create index if not exists generation_jobs_user_status
+  on public.generation_jobs (user_id, status);
+
+create index if not exists generation_jobs_created_at
+  on public.generation_jobs (created_at);

--- a/worker/server.ts
+++ b/worker/server.ts
@@ -1,0 +1,321 @@
+/**
+ * Standalone Cloud Run worker for async campaign generation.
+ * QStash calls this instead of the Vercel route when GENERATION_WORKER_URL is set.
+ * No Vercel timeout applies here — Cloud Run allows up to 60 minutes.
+ *
+ * Run locally:  npx tsx worker/server.ts
+ * Deploy:       see Dockerfile.worker
+ */
+import http from 'http';
+import { createClient } from '@supabase/supabase-js';
+import { Receiver } from '@upstash/qstash';
+import { PostHog } from 'posthog-node';
+import { buildGenerationPrompt } from '@/lib/prompts';
+import {
+  validateCampaign,
+  buildRepairDirective,
+  summarizeForClient,
+  type CampaignShape,
+  type ValidationReport,
+} from '@/lib/prompts/lexicon-validator';
+import { getVertexAIClient } from '@/lib/genai-client';
+import { getGitHubEnrichedContext } from '@/lib/composio';
+import { extractYouTubeId, getYouTubeTranscript } from '@/lib/youtube';
+import { incrementCampaignGeneration } from '@/lib/plan';
+
+const PORT = process.env.PORT || 8080;
+
+const receiver = new Receiver({
+  currentSigningKey: process.env.QSTASH_CURRENT_SIGNING_KEY!,
+  nextSigningKey: process.env.QSTASH_NEXT_SIGNING_KEY!,
+});
+
+function getSupabaseAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Generation logic (mirrors /api/qstash/generate but without the 60s cap)
+// ---------------------------------------------------------------------------
+
+const distributionSchema = {
+  type: 'OBJECT',
+  properties: {
+    campaign: {
+      type: 'ARRAY',
+      items: {
+        type: 'OBJECT',
+        properties: {
+          day: { type: 'INTEGER' },
+          x: { type: 'STRING' },
+          linkedin: { type: 'STRING' },
+          discord: { type: 'STRING' },
+          slack: { type: 'STRING' },
+        },
+        required: ['day', 'x', 'linkedin', 'discord', 'slack'],
+      },
+    },
+    email: { type: 'STRING' },
+  },
+  required: ['campaign'],
+};
+
+async function generateFromParts(parts: any[]): Promise<string> {
+  const client = await getVertexAIClient();
+  const response = await client.models.generateContent({
+    model: 'gemini-3-flash-preview',
+    contents: [{ role: 'user', parts }],
+    config: {
+      responseMimeType: 'application/json',
+      responseSchema: distributionSchema,
+    },
+  });
+
+  const text =
+    response.text ??
+    response.candidates?.[0]?.content?.parts?.[0]?.text ??
+    '';
+
+  if (!text) throw new Error('Empty response from Vertex AI');
+  return text;
+}
+
+// No budget cap here — we're on Cloud Run with a 60-minute timeout.
+async function generateWithLexiconGuard(
+  parts: any[],
+  basePrompt: string,
+  hasImages: boolean,
+): Promise<{ responseText: string; report: ValidationReport; retried: boolean }> {
+  const initial = await generateFromParts(parts);
+
+  let parsed: CampaignShape | null = null;
+  try { parsed = JSON.parse(initial); } catch {
+    return { responseText: initial, report: { violations: [], slopScore: 0, clean: true }, retried: false };
+  }
+
+  const report = validateCampaign(parsed);
+  const retryWorthy =
+    report.slopScore >= 3 ||
+    report.violations.some(
+      (v) => v.kind === 'banned-structure' || v.kind === 'banned-contrast' || v.kind === 'banned-closer'
+    );
+
+  if (!retryWorthy) return { responseText: initial, report, retried: false };
+
+  // On Cloud Run we can always retry — no time budget concern.
+  // Skip only if images are present (they make the request large; one good
+  // pass is usually enough and the retry would cost extra Gemini tokens).
+  if (hasImages) {
+    console.warn('[worker] skipping repair retry: images in payload');
+    return { responseText: initial, report, retried: false };
+  }
+
+  console.log(`[worker] ${report.violations.length} violation(s) (slop=${report.slopScore}); retrying`);
+
+  const repairParts: any[] = [
+    { text: `${basePrompt}\n\n${buildRepairDirective(report)}\n\n## Rejected output (for reference only)\n${initial.slice(0, 4000)}` },
+    ...parts.slice(1),
+  ];
+
+  let retried: string;
+  try { retried = await generateFromParts(repairParts); }
+  catch (err) {
+    console.error('[worker] retry failed, returning original:', err);
+    return { responseText: initial, report, retried: true };
+  }
+
+  let retriedParsed: CampaignShape | null = null;
+  try { retriedParsed = JSON.parse(retried); } catch {
+    return { responseText: initial, report, retried: true };
+  }
+
+  const retriedReport = validateCampaign(retriedParsed);
+  console.log(`[worker] retry: ${retriedReport.violations.length} violation(s) (slop=${retriedReport.slopScore})`);
+
+  return retriedReport.slopScore < report.slopScore
+    ? { responseText: retried, report: retriedReport, retried: true }
+    : { responseText: initial, report, retried: true };
+}
+
+async function processJob(jobId: string): Promise<void> {
+  const startTime = Date.now();
+  const supabase = getSupabaseAdmin();
+
+  const { data: job, error: fetchErr } = await supabase
+    .from('generation_jobs')
+    .select('*')
+    .eq('id', jobId)
+    .single();
+
+  if (fetchErr || !job) throw new Error(`Job ${jobId} not found`);
+
+  if (job.status !== 'pending') {
+    console.log(`[worker] job ${jobId} already processed (${job.status})`);
+    return;
+  }
+
+  await supabase
+    .from('generation_jobs')
+    .update({ status: 'processing', updated_at: new Date().toISOString() })
+    .eq('id', jobId);
+
+  const { sourceMaterial, campaignDirectives, isDemo, userId } = job.payload;
+
+  try {
+    let urlContext = sourceMaterial?.url || '';
+    const textContext = sourceMaterial?.rawText || '';
+    const assetUrls: string[] = sourceMaterial?.assetUrls || [];
+
+    // YouTube transcript
+    let effectiveUrlContext = urlContext;
+    if (urlContext) {
+      const videoId = extractYouTubeId(urlContext);
+      if (videoId) {
+        const transcript = await getYouTubeTranscript(videoId);
+        if (transcript) effectiveUrlContext = `YouTube transcript: ${transcript}`;
+      }
+    }
+
+    // GitHub context
+    let githubContext = '';
+    if (!isDemo && userId) {
+      const { data: githubConn } = await supabase
+        .from('user_composio_connections')
+        .select('connection_id')
+        .eq('user_id', userId)
+        .eq('app', 'github')
+        .maybeSingle();
+
+      if (githubConn) {
+        try { githubContext = await getGitHubEnrichedContext(githubConn.connection_id); }
+        catch (err) { console.error('[worker] GitHub context failed:', err); }
+      }
+    }
+
+    const enhancedText = textContext + githubContext;
+    const tweetFormat = campaignDirectives?.tweetFormat || 'single';
+    const personaVoice = campaignDirectives?.personaVoice || 'Expert Content Strategist';
+    const finalContext = campaignDirectives?.additionalContext
+      ? `${enhancedText}\n\nAdditional Directives: ${campaignDirectives.additionalContext}`
+      : enhancedText;
+
+    const textPrompt = buildGenerationPrompt({ tweetFormat, personaVoice, textContext: finalContext, urlContext: effectiveUrlContext });
+    const parts: any[] = [{ text: textPrompt }];
+
+    for (const assetUrl of assetUrls) {
+      try {
+        const fileRes = await fetch(assetUrl);
+        if (!fileRes.ok) throw new Error(`HTTP ${fileRes.status}`);
+        const mimeType = fileRes.headers.get('content-type') || 'application/octet-stream';
+        const base64Data = Buffer.from(await fileRes.arrayBuffer()).toString('base64');
+        parts.push({ inlineData: { data: base64Data, mimeType } });
+      } catch (err) {
+        console.error(`[worker] Failed to fetch asset ${assetUrl}:`, err);
+      }
+    }
+
+    const { responseText, report: lexiconReport, retried } =
+      await generateWithLexiconGuard(parts, textPrompt, assetUrls.length > 0);
+    const lexiconWarnings = summarizeForClient(lexiconReport);
+
+    await supabase
+      .from('generation_jobs')
+      .update({ status: 'done', result: { output: responseText, lexiconWarnings }, updated_at: new Date().toISOString() })
+      .eq('id', jobId);
+
+    if (!isDemo && userId) await incrementCampaignGeneration(userId);
+
+    const durationMs = Date.now() - startTime;
+    const posthog = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+      host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+    });
+    posthog.capture({
+      distinctId: userId || 'demo',
+      event: isDemo ? 'vertex_generation_completed_demo' : 'vertex_generation_completed',
+      properties: { durationMs, personaVoice, hasFile: assetUrls.length > 0, assetCount: assetUrls.length, status: 'success', lexiconViolations: lexiconReport.violations.length, lexiconSlopScore: lexiconReport.slopScore, lexiconRetried: retried, async: true, runtime: 'cloud-run' },
+    });
+    await posthog.shutdown();
+
+    console.log(`[worker] job ${jobId} done in ${durationMs}ms`);
+  } catch (err: any) {
+    console.error(`[worker] job ${jobId} failed:`, err);
+    await supabase
+      .from('generation_jobs')
+      .update({ status: 'error', error_message: err.message || 'Internal error', updated_at: new Date().toISOString() })
+      .eq('id', jobId);
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP server
+// ---------------------------------------------------------------------------
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'GET' && req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.writeHead(405);
+    res.end();
+    return;
+  }
+
+  // Read body
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  const rawBody = Buffer.concat(chunks).toString();
+
+  // Verify QStash signature
+  const signature = req.headers['upstash-signature'] as string | undefined;
+  if (signature) {
+    try {
+      const isValid = await receiver.verify({ signature, body: rawBody });
+      if (!isValid) {
+        res.writeHead(401);
+        res.end(JSON.stringify({ error: 'Invalid signature' }));
+        return;
+      }
+    } catch {
+      res.writeHead(401);
+      res.end(JSON.stringify({ error: 'Signature verification failed' }));
+      return;
+    }
+  } else if (process.env.NODE_ENV === 'production') {
+    res.writeHead(401);
+    res.end(JSON.stringify({ error: 'Missing signature' }));
+    return;
+  }
+
+  let jobId: string;
+  try {
+    ({ jobId } = JSON.parse(rawBody));
+    if (!jobId) throw new Error('Missing jobId');
+  } catch {
+    res.writeHead(400);
+    res.end(JSON.stringify({ error: 'Invalid body' }));
+    return;
+  }
+
+  try {
+    await processJob(jobId);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ success: true, jobId }));
+  } catch (err: any) {
+    // Return 200 anyway — job status is already written to Supabase as 'error'.
+    // A non-2xx here would cause QStash to retry, but the job is already marked
+    // failed so retries would just no-op (status !== 'pending' guard).
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ success: false, jobId, error: err.message }));
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`[worker] listening on port ${PORT}`);
+});

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "baseUrl": "..",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "outDir": "../dist-worker"
+  },
+  "include": ["server.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- **Replaces synchronous generation** with an enqueue-and-poll flow: `/api/generate` returns a `jobId` in <1s, the frontend polls `/api/generate/status` every 2s, and the heavy Gemini work runs in a separate worker
- **Cloud Run worker** (`worker/server.ts` + `Dockerfile.worker`) removes the 60s limit entirely — set `GENERATION_WORKER_URL` in Vercel to activate it; falls back to the Vercel worker route otherwise
- **Fixes Composio OAuth** redirecting to `localhost:3000` — connect route now derives the app origin from the request URL, not just the env var
- **Fixes persona loading spinner** stuck forever when Supabase call throws
- **Fixes image-heavy generation** — repair retry is now explicitly skipped when assets are in the payload, preventing budget exhaustion

## New files

| File | Purpose |
|---|---|
| `supabase/migrations/011-generation-jobs.sql` | `generation_jobs` table + RLS — **run this first** |
| `app/api/generate/status/route.ts` | Polling endpoint (`GET /api/generate/status?jobId=`) |
| `app/api/qstash/generate/route.ts` | Vercel worker (still 60s capped, used until Cloud Run is wired) |
| `worker/server.ts` | Cloud Run HTTP server — no timeout cap |
| `Dockerfile.worker` | Builds the Cloud Run service from repo root |

## Deploy checklist

- [ ] Run `supabase/migrations/011-generation-jobs.sql` in Supabase SQL editor
- [ ] Set `APP_URL` and `NEXT_PUBLIC_APP_URL` to production domain in Vercel (fixes Composio + QStash)
- [ ] Deploy Cloud Run worker and set `GENERATION_WORKER_URL` in Vercel env vars
- [ ] Confirm `QSTASH_TOKEN`, `QSTASH_CURRENT_SIGNING_KEY`, `QSTASH_NEXT_SIGNING_KEY` are set in Vercel

## Cloud Run deploy (once merged)

```bash
gcloud run deploy ozigi-generator \
  --dockerfile Dockerfile.worker \
  --project ozigi-489021 \
  --region us-central1 \
  --timeout 3600 \
  --memory 512Mi \
  --no-allow-unauthenticated \
  --set-env-vars "NEXT_PUBLIC_SUPABASE_URL=...,SUPABASE_SERVICE_ROLE_KEY=...,QSTASH_CURRENT_SIGNING_KEY=...,QSTASH_NEXT_SIGNING_KEY=...,NEXT_PUBLIC_POSTHOG_KEY=...,GCP_PROJECT_ID=ozigi-489021"

# Get the URL
gcloud run services describe ozigi-generator --region us-central1 --format="value(status.url)"
```

Then set `GENERATION_WORKER_URL=<url>` in Vercel and redeploy.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)