### PR TITLE
feat: trigger generation with Cmd/Ctrl+Enter from the input

### DIFF
--- a/components/ContextEngine.tsx
+++ b/components/ContextEngine.tsx
@@ -161,6 +161,16 @@ export default function Distillery({
               placeholder="Paste a URL, meeting notes, or any text context here..."
               value={inputs.text}
               onChange={(e) => setInputs({ ...inputs, text: e.target.value })}
+              onKeyDown={(e) => {
+                // Cmd+Enter (Mac) / Ctrl+Enter (Win/Linux) triggers generation,
+                // same as the Generate button. Plain Enter still inserts a newline.
+                if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                  e.preventDefault();
+                  if ((inputs.text.trim() || inputs.files.length > 0) && !isUploading) {
+                    onGenerate();
+                  }
+                }
+              }}
             />
           </div>
 


### PR DESCRIPTION
Pressing Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux) in the context box now generates, same as clicking the button.

Plain Enter still makes a newline. It reuses the button's disabled check, so it won't fire on empty input or while a file is uploading, and won't double-submit.

Closes #122