### PR TITLE
feat: on-brand empty state for the output panel

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Mail, Sparkles, User, FileText, Store, LayoutDashboard, Megaphone, ListOrdered, Clock, Settings, Send, UserPlus, AtSign } from "lucide-react";
 import Distillery from "@/components/ContextEngine";
 import DistributionGrid from "@/components/DistributionGrid";
+import OutputEmptyState from "@/components/OutputEmptyState";
 import GuestModeBanner from "@/components/GuestModeBanner";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
@@ -640,6 +641,12 @@ useEffect(() => {
                   onOpenPersonas={() => setIsPersonasOpen(true)}
                   onGenerate={handleGenerate}
                 />
+              )}
+
+              {!loading && campaign.length === 0 && (
+                <div className="mt-6">
+                  <OutputEmptyState />
+                </div>
               )}
 
               {loading && (

--- a/components/OutputEmptyState.tsx
+++ b/components/OutputEmptyState.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { motion } from "framer-motion";
+
+/**
+ * Empty state for the output panel — shown before any campaign has been
+ * generated. Previews the formats Ozigi will produce so first-time users know
+ * what to expect instead of staring at a blank panel.
+ */
+const OUTPUT_TYPES = [
+  { icon: "🧵", label: "X thread" },
+  { icon: "💼", label: "LinkedIn post" },
+  { icon: "✉️", label: "Newsletter" },
+  { icon: "📝", label: "Blog post" },
+  { icon: "💬", label: "Discord / Slack" },
+] as const;
+
+export default function OutputEmptyState() {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4, ease: "easeOut" }}
+      className="flex flex-col items-center text-center rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 px-6 py-10"
+    >
+      <span className="block w-10 h-1 rounded-full bg-brand-red mb-5" aria-hidden />
+      <h3 className="text-sm font-black uppercase tracking-widest text-slate-900">
+        Your campaign will appear here
+      </h3>
+      <p className="mt-2 max-w-sm text-xs font-medium text-slate-500">
+        Add context above and hit Generate to turn it into ready-to-publish posts.
+      </p>
+      <ul className="mt-6 flex flex-wrap items-center justify-center gap-2">
+        {OUTPUT_TYPES.map((t) => (
+          <li
+            key={t.label}
+            className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600"
+          >
+            <span aria-hidden className="text-xs leading-none">{t.icon}</span>
+            {t.label}
+          </li>
+        ))}
+      </ul>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
The output panel is blank before you generate anything. This adds a small placeholder that shows what you'll get (X thread, LinkedIn, newsletter, blog post, Discord/Slack) with a line pointing back at the input. Fades in with framer-motion, uses slate and brand red, wraps on mobile.

New component plus a few lines in the dashboard. I put it right under the input in the social/newsletter view since that's where the output shows up. Move it if you'd rather it sat somewhere else.

Closes #125