### PR TITLE
feat(linkedin): persistent browser login, human behavior, session expiry

### DIFF
--- a/app/api/gtm/notify/session-expired/route.ts
+++ b/app/api/gtm/notify/session-expired/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabase/admin'
+import { SendMailClient } from 'zeptomail'
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * POST /api/gtm/notify/session-expired
+ *
+ * Called by the LinkedIn worker when it marks a session as needs_login.
+ * Looks up the user's email, and sends a "reconnect your LinkedIn" notification.
+ *
+ * Auth: Bearer WORKER_SECRET (same secret the worker uses for /login and /search)
+ */
+export async function POST(req: Request) {
+  // Verify the request comes from our worker
+  const auth = req.headers.get('authorization')
+  if (auth !== `Bearer ${process.env.WORKER_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { userId, linkedinEmail } = await req.json() as {
+    userId: string
+    linkedinEmail: string
+  }
+
+  if (!userId || !linkedinEmail) {
+    return NextResponse.json({ error: 'userId and linkedinEmail required' }, { status: 400 })
+  }
+
+  try {
+    // Look up the user's real email from Supabase auth
+    const { data: { user }, error } = await supabaseAdmin.auth.admin.getUserById(userId)
+    if (error || !user?.email) {
+      console.error(`[notify/session-expired] could not find user ${userId}:`, error?.message)
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const userName = user.user_metadata?.full_name
+      || user.email.split('@')[0]
+      || 'there'
+
+    const settingsUrl = `${process.env.NEXT_PUBLIC_APP_URL}/dashboard/gtm/settings`
+
+    // Load and fill the email template
+    const templatePath = path.join(process.cwd(), 'emails', 'linkedin-session-expired.html')
+    let html = fs.readFileSync(templatePath, 'utf8')
+    html = html
+      .replace(/{{name}}/g, userName)
+      .replace(/{{linkedin_email}}/g, linkedinEmail)
+      .replace(/{{settings_url}}/g, settingsUrl)
+
+    const mailClient = new SendMailClient({
+      url: 'https://api.zeptomail.com/v1.1/email',
+      token: `Zoho-enczapikey ${process.env.ZEPTOMAIL_API_KEY}`,
+    })
+
+    await mailClient.sendMail({
+      from: {
+        address: process.env.WELCOME_EMAIL_FROM_ADDRESS || 'hello@ozigi.app',
+        name:    process.env.WELCOME_EMAIL_FROM_NAME    || 'Ozigi',
+      },
+      to: [{
+        email_address: {
+          address: user.email,
+          name:    userName,
+        },
+      }],
+      subject: `Action needed: reconnect your LinkedIn account (${linkedinEmail})`,
+      htmlbody: html,
+    })
+
+    console.log(`[notify/session-expired] sent reconnect email to ${user.email} for LinkedIn ${linkedinEmail}`)
+    return NextResponse.json({ ok: true })
+
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error('[notify/session-expired] failed:', msg)
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/app/dashboard/gtm/settings/page.tsx
+++ b/app/dashboard/gtm/settings/page.tsx
@@ -82,12 +82,6 @@ function SettingsContent() {
   const [twoFaCode, setTwoFaCode] = useState('')
   const [twoFaSubmitting, setTwoFaSubmitting] = useState(false)
   const [liMsg, setLiMsg] = useState('')
-  const [liMode, setLiMode] = useState<'password' | 'cookie'>('cookie')
-  const [liCookieValue, setLiCookieValue] = useState('')
-  const [liCookieEmail, setLiCookieEmail] = useState('')
-  const [liJsessionId, setLiJsessionId] = useState('')
-  const [liBcookie, setLiBcookie] = useState('')
-  const [liLiA, setLiLiA] = useState('')
 
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
@@ -221,32 +215,6 @@ function SettingsContent() {
       startPolling()
     } else {
       setLiMsg('Could not start LinkedIn login — please check your credentials and try again.')
-    }
-    setLiConnecting(false)
-  }
-
-  async function connectLinkedInCookie(e: React.FormEvent) {
-    e.preventDefault()
-    setLiConnecting(true)
-    setLiMsg('')
-    const res = await fetch('/api/gtm/linkedin/cookie', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        li_at: liCookieValue,
-        linkedin_email: liCookieEmail,
-        jsessionid: liJsessionId || undefined,
-        bcookie: liBcookie || undefined,
-        li_a: liLiA || undefined,
-      }),
-    })
-    const d = await res.json()
-    if (res.ok) {
-      setLiMsg('LinkedIn connected via session cookie.')
-      setLiCookieValue('')
-      loadLinkedIn()
-    } else {
-      setLiMsg(d.error ?? 'Failed to save cookie — please try again.')
     }
     setLiConnecting(false)
   }
@@ -524,7 +492,7 @@ function SettingsContent() {
                 onClick={() => disconnectLinkedIn(s.id)}
                 style={{ padding: '0.3rem 0.7rem', border: '1px solid #fca5a5', borderRadius: 5, background: 'white', color: '#dc2626', cursor: 'pointer', fontSize: '0.85rem', flexShrink: 0 }}
               >
-                {s.status === 'active' ? 'Disconnect' : 'Reconnect'}
+                {s.status === 'active' ? 'Disconnect' : 'Remove'}
               </button>
             </div>
           </div>
@@ -577,129 +545,33 @@ function SettingsContent() {
         {/* Connect form — shown if no active session */}
         {!activeSession && !pendingTwoFa && liSessions.every(s => s.status !== 'logging_in') && (
           <div style={{ border: '1px solid #eee', borderRadius: 8, padding: '1.25rem' }}>
-            <div style={{ fontWeight: 600, marginBottom: '0.25rem' }}>Connect a LinkedIn account</div>
-
-            {/* Mode toggle */}
-            <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem', marginTop: '0.75rem' }}>
-              {(['cookie', 'password'] as const).map(mode => (
-                <button
-                  key={mode}
-                  type="button"
-                  onClick={() => setLiMode(mode)}
-                  style={{
-                    padding: '0.3rem 0.8rem', borderRadius: 5, fontSize: '0.82rem', fontWeight: 600, cursor: 'pointer',
-                    border: liMode === mode ? '1px solid #0a66c2' : '1px solid #ccc',
-                    background: liMode === mode ? '#eff6ff' : 'white',
-                    color: liMode === mode ? '#0a66c2' : '#555',
-                  }}
-                >
-                  {mode === 'cookie' ? 'Session cookie (recommended)' : 'Email & password'}
-                </button>
-              ))}
+            <div style={{ fontWeight: 600, marginBottom: '0.5rem' }}>Connect a LinkedIn account</div>
+            <div style={{ fontSize: '0.82rem', color: '#666', marginBottom: '1rem', lineHeight: 1.6 }}>
+              We log into LinkedIn on your behalf using your credentials. Your password is encrypted at rest and never shared.
             </div>
-
-            {liMode === 'cookie' ? (
-              <>
-                <div style={{ fontSize: '0.82rem', color: '#555', marginBottom: '1rem', lineHeight: 1.7, background: '#f8fafc', border: '1px solid #e2e8f0', borderRadius: 6, padding: '0.75rem 1rem' }}>
-                  <strong>How to get your session cookie:</strong>
-                  <ol style={{ margin: '0.4rem 0 0 1.2rem', padding: 0 }}>
-                    <li>Open <strong>LinkedIn.com</strong> in your browser and make sure you&apos;re logged in.</li>
-                    <li>Open DevTools:
-                      <ul style={{ margin: '0.2rem 0 0 1rem', padding: 0, listStyle: 'disc' }}>
-                        <li><strong>Windows / Linux:</strong> press <strong>F12</strong> or <strong>Ctrl + Shift + I</strong></li>
-                        <li><strong>Mac:</strong> press <strong>Cmd + Option + I</strong></li>
-                        <li>Or: right-click anywhere on the page → <strong>Inspect</strong></li>
-                      </ul>
-                    </li>
-                    <li>Click the <strong>Application</strong> tab (Chrome) or <strong>Storage</strong> tab (Firefox).</li>
-                    <li>In the left sidebar, expand <strong>Cookies</strong> → click <strong>https://www.linkedin.com</strong>.</li>
-                    <li>Copy the <strong>Value</strong> for each of these cookies into the fields below:
-                      <ul style={{ margin: '0.2rem 0 0 1rem', padding: 0, listStyle: 'disc' }}>
-                        <li><strong>li_at</strong> — required (your auth token)</li>
-                        <li><strong>JSESSIONID</strong> — recommended (session ID, helps keep you logged in)</li>
-                        <li><strong>bcookie</strong> — recommended (browser ID, prevents session drops)</li>
-                      </ul>
-                    </li>
-                  </ol>
-                </div>
-                <form onSubmit={connectLinkedInCookie} style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-                  <input
-                    type="email"
-                    value={liCookieEmail}
-                    onChange={e => setLiCookieEmail(e.target.value)}
-                    placeholder="Your LinkedIn email address"
-                    style={{ padding: '0.5rem 0.75rem', border: '1px solid #ccc', borderRadius: 5, fontSize: '0.95rem' }}
-                  />
-                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-                    <span style={{ fontSize: '0.78rem', fontWeight: 600, color: '#444' }}>li_at <span style={{ color: '#dc2626' }}>*</span></span>
-                    <input
-                      type="text"
-                      value={liCookieValue}
-                      onChange={e => setLiCookieValue(e.target.value)}
-                      placeholder="AQEDATd8MXcF..."
-                      style={{ padding: '0.5rem 0.75rem', border: '1px solid #ccc', borderRadius: 5, fontSize: '0.85rem', fontFamily: 'monospace' }}
-                    />
-                  </label>
-                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-                    <span style={{ fontSize: '0.78rem', fontWeight: 600, color: '#444' }}>JSESSIONID <span style={{ fontSize: '0.75rem', color: '#888', fontWeight: 400 }}>recommended</span></span>
-                    <input
-                      type="text"
-                      value={liJsessionId}
-                      onChange={e => setLiJsessionId(e.target.value)}
-                      placeholder="ajax:1234567890123456789"
-                      style={{ padding: '0.5rem 0.75rem', border: '1px solid #ccc', borderRadius: 5, fontSize: '0.85rem', fontFamily: 'monospace' }}
-                    />
-                  </label>
-                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-                    <span style={{ fontSize: '0.78rem', fontWeight: 600, color: '#444' }}>bcookie <span style={{ fontSize: '0.75rem', color: '#888', fontWeight: 400 }}>recommended</span></span>
-                    <input
-                      type="text"
-                      value={liBcookie}
-                      onChange={e => setLiBcookie(e.target.value)}
-                      placeholder="v=2&amp;26d6ae18-f2b4-4d4a-..."
-                      style={{ padding: '0.5rem 0.75rem', border: '1px solid #ccc', borderRadius: 5, fontSize: '0.85rem', fontFamily: 'monospace' }}
-                    />
-                  </label>
-                  <button
-                    type="submit"
-                    disabled={liConnecting || !liCookieEmail || !liCookieValue}
-                    style={{ padding: '0.55rem 1.25rem', background: liConnecting ? '#999' : '#0a66c2', color: '#fff', border: 'none', borderRadius: 5, cursor: 'pointer', fontSize: '0.95rem', alignSelf: 'flex-start' }}
-                  >
-                    {liConnecting ? 'Saving…' : 'Connect LinkedIn'}
-                  </button>
-                </form>
-              </>
-            ) : (
-              <>
-                <div style={{ fontSize: '0.82rem', color: '#666', marginBottom: '1rem', lineHeight: 1.6 }}>
-                  We log into LinkedIn on your behalf using your credentials.
-                  Your password is encrypted at rest and never shared.
-                </div>
-                <form onSubmit={connectLinkedIn} style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-                  <input
-                    type="email"
-                    value={liEmail}
-                    onChange={e => setLiEmail(e.target.value)}
-                    placeholder="LinkedIn email"
-                    style={{ padding: '0.5rem 0.75rem', border: '1px solid #ccc', borderRadius: 5, fontSize: '0.95rem' }}
-                  />
-                  <input
-                    type="password"
-                    value={liPassword}
-                    onChange={e => setLiPassword(e.target.value)}
-                    placeholder="LinkedIn password"
-                    style={{ padding: '0.5rem 0.75rem', border: '1px solid #ccc', borderRadius: 5, fontSize: '0.95rem' }}
-                  />
-                  <button
-                    type="submit"
-                    disabled={liConnecting || !liEmail || !liPassword}
-                    style={{ padding: '0.55rem 1.25rem', background: liConnecting ? '#999' : '#0a66c2', color: '#fff', border: 'none', borderRadius: 5, cursor: 'pointer', fontSize: '0.95rem', alignSelf: 'flex-start' }}
-                  >
-                    {liConnecting ? 'Connecting…' : 'Connect LinkedIn'}
-                  </button>
-                </form>
-              </>
-            )}
+            <form onSubmit={connectLinkedIn} style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+              <input
+                type="email"
+                value={liEmail}
+                onChange={e => setLiEmail(e.target.value)}
+                placeholder="LinkedIn email"
+                style={{ padding: '0.5rem 0.75rem', border: '1px solid #ccc', borderRadius: 5, fontSize: '0.95rem' }}
+              />
+              <input
+                type="password"
+                value={liPassword}
+                onChange={e => setLiPassword(e.target.value)}
+                placeholder="LinkedIn password"
+                style={{ padding: '0.5rem 0.75rem', border: '1px solid #ccc', borderRadius: 5, fontSize: '0.95rem' }}
+              />
+              <button
+                type="submit"
+                disabled={liConnecting || !liEmail || !liPassword}
+                style={{ padding: '0.55rem 1.25rem', background: liConnecting ? '#999' : '#0a66c2', color: '#fff', border: 'none', borderRadius: 5, cursor: 'pointer', fontSize: '0.95rem', alignSelf: 'flex-start' }}
+              >
+                {liConnecting ? 'Connecting…' : 'Connect LinkedIn'}
+              </button>
+            </form>
           </div>
         )}
       </section>

--- a/emails/linkedin-session-expired.html
+++ b/emails/linkedin-session-expired.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reconnect your LinkedIn account</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #1e293b; background-color: #fafafa; margin: 0; padding: 0; }
+    .container { max-width: 600px; margin: 0 auto; padding: 40px 20px; background-color: #ffffff; border-radius: 24px; margin-top: 20px; margin-bottom: 20px; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1); }
+    .header { text-align: center; margin-bottom: 32px; }
+    .logo { font-size: 32px; font-weight: 900; letter-spacing: -0.02em; color: #0a1628; text-decoration: none; }
+    .logo span { color: #e8320a; }
+    .alert-icon { font-size: 48px; text-align: center; margin: 16px 0; }
+    h1 { font-size: 24px; font-weight: 800; margin: 16px 0; letter-spacing: -0.01em; }
+    p { color: #475569; margin: 12px 0; }
+    .account-badge { display: inline-block; background: #f1f5f9; border: 1px solid #e2e8f0; border-radius: 8px; padding: 6px 12px; font-size: 14px; font-weight: 600; color: #0a1628; margin: 8px 0; }
+    .button-wrap { text-align: center; margin: 32px 0; }
+    .button { display: inline-block; background-color: #e8320a; color: white !important; padding: 14px 32px; border-radius: 12px; text-decoration: none; font-weight: 700; font-size: 16px; }
+    .why-box { background: #fef9f0; border: 1px solid #fed7aa; border-radius: 12px; padding: 16px 20px; margin: 24px 0; }
+    .why-box p { color: #92400e; font-size: 14px; margin: 0; }
+    .footer { text-align: center; margin-top: 32px; padding-top: 24px; border-top: 1px solid #e2e8f0; font-size: 12px; color: #94a3b8; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="logo">Ozigi<span>.</span></div>
+    </div>
+
+    <div class="alert-icon">🔗</div>
+    <h1>Your LinkedIn session needs reconnecting</h1>
+
+    <p>Hi {{name}},</p>
+
+    <p>Your LinkedIn outreach pipeline paused because the session for:</p>
+
+    <p><span class="account-badge">{{linkedin_email}}</span></p>
+
+    <p>...was no longer authenticated. This usually happens when LinkedIn logs out the session after detecting activity from a new location or device.</p>
+
+    <p><strong>Your queue is safe</strong> — all pending connection requests are preserved and will resume automatically once you reconnect.</p>
+
+    <div class="button-wrap">
+      <a href="{{settings_url}}" class="button">Reconnect LinkedIn →</a>
+    </div>
+
+    <div class="why-box">
+      <p>⏱ <strong>Takes about 30 seconds.</strong> Click the button above, go to the LinkedIn section in Settings, and sign in with your credentials. The pipeline will pick up where it left off.</p>
+    </div>
+
+    <p style="font-size: 14px; color: #94a3b8;">If you didn't set up LinkedIn outreach or this email was sent in error, you can safely ignore it.</p>
+
+    <div class="footer">
+      <p>Ozigi · Automated outreach, done right</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/workers/linkedin/actions.ts
+++ b/workers/linkedin/actions.ts
@@ -1,8 +1,75 @@
-import type { BrowserContext } from 'patchright'
+import type { BrowserContext, Page } from 'patchright'
 
 function delay(minMs: number, maxMs: number): Promise<void> {
   const ms = Math.floor(Math.random() * (maxMs - minMs) + minMs)
   return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Wander the LinkedIn feed like a real user before navigating to a profile.
+ *
+ * Does three things to break automation patterns:
+ *  1. Scrolls down the feed in natural reading increments with random pauses
+ *  2. Hovers over a few in-feed profile links (triggers LinkedIn's hover-card JS)
+ *  3. 30% of the time briefly visits /notifications/ then comes back
+ *
+ * Total dwell: 20–50 s — enough for PerimeterX to record natural behaviour
+ * signals without adding too much latency.
+ */
+async function humanWander(page: Page): Promise<void> {
+  try {
+    // ── 1. Natural scroll through the feed ─────────────────────────────────
+    let scrollPos = 0
+    // Scroll down in 4-8 steps over ~15-30 seconds
+    const steps = Math.floor(Math.random() * 5 + 4)
+    for (let i = 0; i < steps; i++) {
+      const amount = Math.floor(Math.random() * 280 + 120)
+      scrollPos += amount
+      await page.evaluate((y: number) => window.scrollTo({ top: y, behavior: 'smooth' }), scrollPos)
+      // Pause as if reading the post (longer pauses feel more natural)
+      await delay(1500, 4500)
+      // Occasionally scroll back up a little (re-reading behaviour)
+      if (Math.random() < 0.25) {
+        scrollPos = Math.max(0, scrollPos - Math.floor(Math.random() * 150 + 50))
+        await page.evaluate((y: number) => window.scrollTo({ top: y, behavior: 'smooth' }), scrollPos)
+        await delay(800, 2000)
+      }
+    }
+
+    // ── 2. Hover over a couple of profile links in the feed ─────────────────
+    // Real users frequently hover over names — LinkedIn fires hover-card events
+    const profileLinks = await page.locator('a[href*="/in/"]:visible').all().catch(() => [])
+    const toHover = profileLinks.slice(0, Math.floor(Math.random() * 3 + 1))
+    for (const link of toHover) {
+      await link.hover({ timeout: 2_000 }).catch(() => {})
+      await delay(600, 1800)
+    }
+
+    // ── 3. 30% chance: visit /notifications/ briefly ─────────────────────────
+    if (Math.random() < 0.30) {
+      await page.goto('https://www.linkedin.com/notifications/', {
+        waitUntil: 'commit',
+        timeout: 15_000,
+      }).catch(() => {})
+      await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+      // Scroll notifications a little
+      await page.evaluate(() => window.scrollTo({ top: 300, behavior: 'smooth' })).catch(() => {})
+      await delay(3000, 7000)
+      // Go back to feed
+      await page.goto('https://www.linkedin.com/feed/', {
+        waitUntil: 'commit',
+        timeout: 15_000,
+      }).catch(() => {})
+      await delay(1500, 3000)
+    }
+
+    // Scroll back to top before leaving
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' })).catch(() => {})
+    await delay(500, 1200)
+
+  } catch {
+    // Wander is best-effort — never block the connect action
+  }
 }
 
 async function humanType(page: import('playwright').Page, selector: string, text: string) {
@@ -20,24 +87,31 @@ async function humanType(page: import('playwright').Page, selector: string, text
 async function clickConnectButton(page: import('playwright').Page): Promise<boolean> {
 
   // 1. Direct top-level Connect/Invite button via Playwright role locator (most reliable)
-  const directConnect = page.getByRole('button', { name: /^(Connect|Invite .* to connect)$/i })
+  //    Covers English + Portuguese ("Conectar", "Convidar") + Spanish ("Conectar") + French ("Se connecter")
+  const directConnect = page.getByRole('button', {
+    name: /^(Connect|Invite .* to connect|Conectar|Convidar .* para se conectar|Convidar para se conectar|Se connecter|Conectar con)$/i,
+  })
   if (await directConnect.first().isVisible({ timeout: 3_000 }).catch(() => false)) {
     await directConnect.first().click()
     return true
   }
 
-  // 2. Aria-label fallback — catches "Invite Jane to connect" etc.
+  // 2. Aria-label fallback — catches "Invite Jane to connect" / "Convidar Jane para se conectar" etc.
   const ariaConnect = page.locator(
-    'button[aria-label*="Invite"][aria-label*="connect"], button[aria-label*="Connect"]:not([aria-label*="More"])'
+    'button[aria-label*="Invite"][aria-label*="connect"], button[aria-label*="Connect"]:not([aria-label*="More"]),' +
+    'button[aria-label*="Convidar"][aria-label*="conectar"], button[aria-label*="Conectar"]:not([aria-label*="Mais"])'
   ).first()
   if (await ariaConnect.isVisible({ timeout: 2_000 }).catch(() => false)) {
     await ariaConnect.click()
     return true
   }
 
-  // 3. JS scan of all buttons — catches React-rendered variants where aria-label
-  //    lags behind the visible text during hydration
-  const directJS = await page.evaluate(() => {
+  // 3. JS scan — find the Connect button, then use a real Playwright click.
+  //    dispatchEvent was here previously but synthetic events skip LinkedIn's
+  //    full click handler and cause LinkedIn to send the request without
+  //    showing the "Add a note" modal. We find the button with JS and then
+  //    hand back to Playwright for the actual click.
+  const connectBtnText = await page.evaluate(() => {
     for (const btn of Array.from(document.querySelectorAll('button'))) {
       const label = (btn.getAttribute('aria-label') ?? '').toLowerCase()
       const text  = (btn.textContent ?? '').trim().toLowerCase()
@@ -46,20 +120,28 @@ async function clickConnectButton(page: import('playwright').Page): Promise<bool
       const isNotMore = !label.includes('more') && text !== 'message' &&
                         text !== 'follow' && text !== 'following'
       if (isConnect && isNotMore) {
-        btn.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }))
-        btn.dispatchEvent(new MouseEvent('mouseup',   { bubbles: true, cancelable: true }))
-        btn.dispatchEvent(new MouseEvent('click',     { bubbles: true, cancelable: true }))
-        return true
+        // Return the aria-label or text so Playwright can locate it properly
+        return btn.getAttribute('aria-label') || btn.textContent?.trim() || 'Connect'
       }
     }
-    return false
+    return null
   })
-  if (directJS) return true
+  if (connectBtnText) {
+    // Use a real Playwright click so LinkedIn's full click handler fires (required for the modal)
+    const jsFoundBtn = page.locator(`button[aria-label="${connectBtnText}"]`)
+      .or(page.locator('button').filter({ hasText: new RegExp(`^${connectBtnText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`) }))
+      .first()
+    if (await jsFoundBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await jsFoundBtn.click()
+      console.log(`[actions] Connect clicked via JS-found button: "${connectBtnText.slice(0, 40)}"`)
+      return true
+    }
+  }
 
   // 4. More actions dropdown — Connect is hidden here for many profiles
   //    Use getByRole for the button (robust against class name changes)
-  const moreBtn = page.getByRole('button', { name: /More actions/i })
-    .or(page.locator('button').filter({ hasText: /^More$/ }))
+  const moreBtn = page.getByRole('button', { name: /More actions|Mais ações|Más acciones|Plus d'actions/i })
+    .or(page.locator('button').filter({ hasText: /^(More|Mais|Más|Plus)$/ }))
     .first()
 
   const moreVisible = await moreBtn.isVisible({ timeout: 3_000 }).catch(() => false)
@@ -97,9 +179,9 @@ async function clickConnectButton(page: import('playwright').Page): Promise<bool
 
   // Click Connect/Invite inside the dropdown via Playwright locator (real click, not dispatch)
   const connectItem = dropdownOpened
-    ? dropdownInner.locator('li').filter({ hasText: /connect|invite/i }).first()
+    ? dropdownInner.locator('li').filter({ hasText: /connect|invite|conectar|convidar/i }).first()
     : page.locator('[role="listbox"] li, [role="menu"] li, [role="menuitem"]')
-        .filter({ hasText: /connect|invite/i }).first()
+        .filter({ hasText: /connect|invite|conectar|convidar/i }).first()
 
   if (await connectItem.isVisible({ timeout: 2_000 }).catch(() => false)) {
     await connectItem.click()
@@ -117,7 +199,8 @@ async function clickConnectButton(page: import('playwright').Page): Promise<bool
     for (const sel of selectors) {
       for (const el of Array.from(document.querySelectorAll(sel))) {
         const text = (el.textContent ?? '').toLowerCase()
-        if (text.includes('connect') || text.includes('invite')) {
+        if (text.includes('connect') || text.includes('invite') ||
+            text.includes('conectar') || text.includes('convidar')) {
           const clickable = (el.querySelector('button, a') ?? el) as HTMLElement
           clickable.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
           return true
@@ -139,27 +222,26 @@ export async function sendConnectionRequest(
   const page = await context.newPage()
 
   try {
-    // Prime localStorage before visiting the profile. LinkedIn's SPA checks
-    // localStorage for auth state when loading a profile page — a blank
-    // localStorage triggers a client-side redirect to the auth wall even
-    // when li_at is valid. Visiting the feed on the same page lets LinkedIn's
-    // JavaScript populate localStorage, then the profile navigation finds it
-    // already set and loads normally.
+    // Visit the feed to prime localStorage AND wander like a real user.
+    // LinkedIn's SPA checks localStorage for auth state before rendering
+    // a profile — visiting the feed first populates it. We then wander
+    // (scroll, hover, sometimes check notifications) to generate natural
+    // behavioural signals for PerimeterX before arriving at the profile.
     await page.goto('https://www.linkedin.com/feed/', {
       waitUntil: 'commit',   // fires on first byte — safe through proxy
       timeout: 15_000,
     }).catch(() => {})
     // Wait for HTML to be fully parsed (scripts are now downloading)
     await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
-    // Wait for LinkedIn's React app to initialise and write auth state to
-    // localStorage. Without this, the profile SPA sees empty localStorage and
-    // triggers a client-side redirect to the auth wall.
+    // Wait for LinkedIn's React app to initialise and write auth state to localStorage.
     await page.waitForFunction(
       () => Object.keys(localStorage).some(k => k.startsWith('voyager-web:')),
       { timeout: 12_000 }
     ).catch(() => {})
-    // Extra settle for any remaining async writes
-    await delay(2000, 3000)
+
+    // Wander the feed like a human — scroll, hover, maybe check notifications.
+    // This breaks the robotic direct-goto-then-connect pattern that PerimeterX flags.
+    await humanWander(page)
 
     await page.goto(linkedinUrl, { waitUntil: 'commit', timeout: 60_000 })
     await page.waitForLoadState('domcontentloaded', { timeout: 30_000 }).catch(() => {})
@@ -171,25 +253,31 @@ export async function sendConnectionRequest(
 
     // Wait for the SPA to render the profile — the title changes from the
     // generic "LinkedIn" shell to the person's name once data is loaded.
-    // 45s covers slow proxied connections. artdeco-spinner intentionally
-    // NOT checked here — it appears on many parts of the page, not just
-    // during initial load, and would cause this to never resolve.
+    // 90s covers slow proxied connections (50+ assets × ~2s each through IPRoyal).
     await page.waitForFunction(
       () => {
         const t = document.title
         return (t && t !== 'LinkedIn' && t.length > 0) ||
                !!document.querySelector('.pvs-profile-actions, [data-member-id]')
       },
-      { timeout: 45_000 }
+      { timeout: 90_000 }
     ).catch(() => {})
 
     // Extra settle time for buttons to render after data arrives
     await delay(2000, 3000)
 
+    // Re-check the URL after waiting — a client-side redirect to /login or
+    // /authwall would change the URL here even if it didn't at commit time.
+    const currentUrl = page.url()
+    if (currentUrl.includes('/login') || currentUrl.includes('/authwall') || currentUrl.includes('/checkpoint')) {
+      throw new Error('AUTHWALL: LinkedIn redirected to login/authwall after profile load')
+    }
+
     const pageState = await page.evaluate(() => ({
       btnCount: document.querySelectorAll('button').length,
       bodyLen:  (document.body.textContent ?? '').trim().length,
       title:    document.title,
+      url:      location.href,
     })).catch(err => {
       const msg = String(err)
       if (msg.includes('Execution context was destroyed') || msg.includes('Target page')) {
@@ -198,21 +286,50 @@ export async function sendConnectionRequest(
       throw err
     })
 
+    console.log(`[actions] profile loaded — title="${pageState.title.slice(0, 60)}" btns=${pageState.btnCount} url=${pageState.url.slice(0, 80)}`)
+
     if (pageState.btnCount === 0 && pageState.bodyLen < 50) {
-      throw new Error('SESSION_EXPIRED: LinkedIn returned a blank page — please reconnect your account')
+      // Blank page = LinkedIn temporarily blocked this request (bot detection / rate limit).
+      // The session itself is still valid — the feed loaded fine moments ago.
+      // Throw a non-SESSION_EXPIRED error so the worker retries without expiring the session.
+      throw new Error('BLANK_PAGE: LinkedIn served an empty page — temporary block, will retry')
     }
 
-    if (pageState.title === 'LinkedIn') {
+    // Only treat as AUTHWALL if the URL actually redirected away from the profile.
+    // title==='LinkedIn' with URL still on /in/ means the profile is loading slowly — continue anyway.
+    if (pageState.title === 'LinkedIn' &&
+        !pageState.url.includes('/in/') && !pageState.url.includes('/pub/')) {
       throw new Error('AUTHWALL: LinkedIn showed sign-in wall on profile — session may need reconnecting')
     }
+
+    // Human-like scroll behaviour — real users scroll down to read the profile
+    // before clicking Connect. Doing this before button search adds natural dwell
+    // time and generates the scroll events PerimeterX expects from real users.
+    await page.evaluate(() => {
+      const scrollStep = () => new Promise<void>(r => {
+        let pos = 0
+        const step = () => {
+          pos += Math.floor(Math.random() * 120 + 60)
+          window.scrollTo({ top: pos, behavior: 'smooth' })
+          if (pos < 600) setTimeout(step, Math.floor(Math.random() * 200 + 100))
+          else r()
+        }
+        step()
+      })
+      return scrollStep()
+    }).catch(() => {})
+    await delay(800, 1500)
+    // Scroll back up so the top action buttons are in view
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' })).catch(() => {})
+    await delay(500, 900)
 
     const connectClicked = await clickConnectButton(page)
 
     if (!connectClicked) {
       const main = page.locator('main').first()
-      const isPending   = await main.locator('button:has-text("Pending")').isVisible({ timeout: 2_000 }).catch(() => false)
-      const isMessage   = await main.locator('button:has-text("Message")').isVisible({ timeout: 1_000 }).catch(() => false)
-      const isFollowing = await main.locator('button:has-text("Following")').isVisible({ timeout: 1_000 }).catch(() => false)
+      const isPending   = await main.locator('button:has-text("Pending"), button:has-text("Pendente"), button:has-text("Pendiente")').isVisible({ timeout: 2_000 }).catch(() => false)
+      const isMessage   = await main.locator('button:has-text("Message"), button:has-text("Mensagem"), button:has-text("Mensaje"), button:has-text("Envoyer un message")').isVisible({ timeout: 1_000 }).catch(() => false)
+      const isFollowing = await main.locator('button:has-text("Following"), button:has-text("Seguindo"), button:has-text("Siguiendo"), button:has-text("Abonné")').isVisible({ timeout: 1_000 }).catch(() => false)
 
       // Check connection degree: "1st" in page = already connected;
       // no "1st" + Message button = Open Profile (Premium, allows anyone to message)
@@ -253,48 +370,163 @@ export async function sendConnectionRequest(
 
     await delay(1000, 2000)
 
-    // "How do you know X?" relationship step LinkedIn sometimes inserts
-    const otherBtn = page.locator('button:has-text("Other")').first()
-    if (await otherBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
-      await otherBtn.click()
-      await delay(500, 1000)
-    }
-    const nextBtn = page.locator('button:has-text("Next")').first()
-    if (await nextBtn.isVisible({ timeout: 1_500 }).catch(() => false)) {
-      await nextBtn.click()
-      await delay(600, 1200)
-    }
+    // Diagnostic: log all visible buttons so we can see what the modal/page shows
+    const postConnectBtns = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('button'))
+        .filter(b => (b as HTMLElement).offsetParent !== null)
+        .map(b => `"${(b.textContent ?? '').trim().replace(/\s+/g, ' ').slice(0, 50)}"`)
+        .filter(t => t !== '""')
+        .join(' | ')
+    ).catch(() => 'evaluate failed')
+    console.log(`[actions] post-connect visible buttons: ${postConnectBtns}`)
 
-    if (note) {
-      const addNoteBtn = page.locator('button:has-text("Add a note")').first()
-      if (await addNoteBtn.isVisible({ timeout: 4_000 }).catch(() => false)) {
-        await addNoteBtn.click()
-        await delay(600, 1200)
-        const textarea = page.locator(
-          'textarea[name="message"], textarea#custom-message, textarea'
-        ).first()
-        await textarea.waitFor({ state: 'visible', timeout: 5_000 })
-        await textarea.click()
-        await delay(300, 600)
-        for (const char of note) {
-          await page.keyboard.type(char)
-          await delay(40, 120)
-        }
-        await delay(600, 1200)
-        await page.locator('button:has-text("Send")').first().click({ timeout: 8_000 })
-      } else {
-        await page.locator(
-          'button:has-text("Send without a note"), button:has-text("Send"), button:has-text("Send now")'
-        ).first().click({ timeout: 8_000 })
+    // ── Modal-first approach ───────────────────────────────────────────────────
+    // IMPORTANT: check for the modal BEFORE checking for direct-send indicators.
+    // LinkedIn sometimes fires an "Invitation sent" toast while ALSO rendering
+    // the note modal — if we check body text first we'd bail out and miss the
+    // chance to attach a note.  Wait up to 6 s for the modal; only fall back
+    // to direct-send detection if it genuinely doesn't appear.
+    //
+    // Scope all modal interactions to the invite overlay to avoid false matches
+    // on profile-page pagination buttons and "People Also Viewed" Connect buttons.
+    const modal = page.locator(
+      '[data-test-modal-id="send-invite-modal"], [data-test-modal-container], .artdeco-modal__content, [role="dialog"]'
+    ).first()
+
+    const modalAppeared = await modal.waitFor({ state: 'visible', timeout: 6_000 })
+      .then(() => true).catch(() => false)
+
+    if (modalAppeared) {
+      console.log('[actions] note modal appeared — attaching note')
+
+      // "How do you know X?" relationship step LinkedIn sometimes inserts
+      // Selectors cover English + Portuguese (Outro/Avançar) + Spanish (Otro/Siguiente) + French (Autre/Suivant)
+      const otherBtn = modal.locator('button:has-text("Other"), button:has-text("Outro"), button:has-text("Otro"), button:has-text("Autre")').first()
+      if (await otherBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+        await otherBtn.click()
+        await delay(500, 1000)
       }
+      const nextBtn = modal.locator('button:has-text("Next"), button:has-text("Avançar"), button:has-text("Próximo"), button:has-text("Siguiente"), button:has-text("Suivant")').first()
+      if (await nextBtn.isVisible({ timeout: 1_500 }).catch(() => false)) {
+        await nextBtn.click()
+        await delay(600, 1200)
+      }
+
+      // Send button selector covers English + Portuguese + Spanish + French
+      const SEND_SELECTOR =
+        'button:has-text("Send without a note"), button:has-text("Send"), button:has-text("Send now"), ' +
+        'button:has-text("Enviar sem uma nota"), button:has-text("Enviar sem nota"), button:has-text("Enviar"), ' +
+        'button:has-text("Enviar sin nota"), button:has-text("Envoyer sans note"), button:has-text("Envoyer")'
+
+      if (note) {
+        const addNoteBtn = modal.locator(
+          'button:has-text("Add a note"), button:has-text("Adicionar uma nota"), button:has-text("Agregar una nota"), button:has-text("Ajouter une note")'
+        ).first()
+        if (await addNoteBtn.isVisible({ timeout: 4_000 }).catch(() => false)) {
+          await addNoteBtn.click()
+          await delay(600, 1200)
+          const textarea = modal.locator(
+            'textarea[name="message"], textarea#custom-message, textarea'
+          ).first()
+          await textarea.waitFor({ state: 'visible', timeout: 5_000 })
+          await textarea.click()
+          await delay(300, 600)
+          for (const char of note) {
+            await page.keyboard.type(char)
+            await delay(40, 120)
+          }
+          await delay(600, 1200)
+          await modal.locator(SEND_SELECTOR).first().click({ timeout: 8_000 })
+          console.log('[actions] connection sent with note ✓')
+        } else {
+          // "Add a note" button not present inside modal — send without note
+          console.log('[actions] modal open but "Add a note" not found — sending without note')
+          await modal.locator(SEND_SELECTOR).first().click({ timeout: 8_000 })
+        }
+      } else {
+        await modal.locator(SEND_SELECTOR).first().click({ timeout: 8_000 })
+      }
+
     } else {
-      await page.locator(
-        'button:has-text("Send without a note"), button:has-text("Send"), button:has-text("Send now")'
-      ).first().click({ timeout: 8_000 })
+      // Modal did not appear — LinkedIn sent the request directly (no note option).
+      // Use page.evaluate for the state check: Playwright locators can miss buttons
+      // that briefly leave and re-enter the DOM during React re-renders after the
+      // 6-second modal wait.
+      const directSendState = await page.evaluate(() => {
+        const body = (document.body.textContent ?? '').toLowerCase()
+
+        const sentToasts = [
+          'invitation sent', 'solicitação enviada', 'solicitud enviada',
+          'invitation envoyée', 'einladung gesendet', 'request sent',
+          'connection request sent',
+        ]
+        const hasSentToast = sentToasts.some(s => body.includes(s))
+
+        // Check the first 20 buttons on the page (profile action area)
+        // for Pending/Cancel which indicate a request was sent directly.
+        const topButtons = Array.from(document.querySelectorAll('button')).slice(0, 20)
+        const hasPending = topButtons.some(b => {
+          const t = (b.textContent ?? '').trim().toLowerCase()
+          return t === 'pending' || t === 'pendente' || t === 'pendiente' ||
+                 t === 'en attente' || t === 'cancel' // LinkedIn sometimes uses Cancel
+        })
+        // Also check aria-labels
+        const hasPendingAria = !!document.querySelector(
+          'button[aria-label*="Pending"], button[aria-label*="Pendente"], button[aria-label*="Cancel request"]'
+        )
+
+        return { hasSentToast, hasPending: hasPending || hasPendingAria }
+      }).catch(() => ({ hasSentToast: false, hasPending: false }))
+
+      if (directSendState.hasSentToast || directSendState.hasPending) {
+        console.log('[actions] connection sent directly by LinkedIn (no note modal — no note attached)')
+        await delay(500, 1000)
+      } else {
+        // Neither modal nor direct-send signal — log the state but don't throw;
+        // the connection may still have gone through silently.
+        console.log('[actions] WARNING: no modal and no direct-send signal — connection state unclear')
+      }
     }
 
     await delay(1000, 2000)
 
+  } finally {
+    await page.close()
+  }
+}
+
+/**
+ * Checks whether a LinkedIn connection invitation has been accepted.
+ * Returns true if the target profile shows as 1st-degree connection.
+ *
+ * Used by the follow-up sequence: before sending a message, the worker
+ * confirms the connection was accepted. If not yet accepted, the queue
+ * item is rescheduled for 24h later without consuming an attempt.
+ */
+export async function checkConnectionAccepted(
+  context: BrowserContext,
+  linkedinUrl: string
+): Promise<boolean> {
+  const page = await context.newPage()
+  try {
+    await page.goto(linkedinUrl, { waitUntil: 'commit', timeout: 30_000 })
+    await page.waitForLoadState('domcontentloaded', { timeout: 20_000 }).catch(() => {})
+    // Give React a moment to render the connection degree badge
+    await page.waitForTimeout(3000)
+
+    return await page.evaluate(() => {
+      const body = document.body.textContent ?? ''
+      // LinkedIn shows "1st" degree badge on connected profiles.
+      // Check the body text AND the aria-label on the degree indicator.
+      const bodyHas1st = /\b1st\b/.test(body)
+      const has1stLabel = !!document.querySelector(
+        '[aria-label*="1st degree"], [aria-label*="1º grau"], [aria-label*="1er degré"]'
+      )
+      // The "Message" button present + no "Connect" button = 1st degree
+      const hasMessage = !!document.querySelector('button[aria-label*="Message"], button[aria-label*="Mensagem"]')
+      const hasConnect = !!document.querySelector('button[aria-label*="Connect"], button[aria-label*="Conectar"]')
+      return bodyHas1st || has1stLabel || (hasMessage && !hasConnect)
+    }).catch(() => false)
   } finally {
     await page.close()
   }

--- a/workers/linkedin/index.ts
+++ b/workers/linkedin/index.ts
@@ -21,7 +21,7 @@ import http from 'http'
 import { createClient } from '@supabase/supabase-js'
 import ws from 'ws'
 import { loadSession, saveSession, markSessionExpired, isLoggedIn } from './browser'
-import { sendConnectionRequest, sendLinkedInMessage, sendFollowUp } from './actions'
+import { sendConnectionRequest, sendLinkedInMessage, sendFollowUp, checkConnectionAccepted } from './actions'
 import { loginLinkedIn } from './login'
 import { searchAndSaveLeads } from './search'
 import type { BrowserContext } from 'patchright'
@@ -108,6 +108,7 @@ const server = http.createServer(async (req, res) => {
       try {
         if (!await isLoggedIn(context)) {
           await markSessionExpired(session.id)
+          notifySessionExpired(userId, session.linkedin_email).catch(() => {})
           await context.close().catch(() => {})
           contextCache.delete(userId)
           console.warn(`[worker:search] session expired for ${session.linkedin_email}`); return
@@ -168,7 +169,7 @@ server.listen(process.env.PORT ?? 8080, () => {
 })
 
 const POLL_INTERVAL_MS    = 90_000
-const ACTION_DELAY_MS     = [120_000, 240_000] as const
+const ACTION_DELAY_MS     = [180_000, 420_000] as const  // 3–7 min — wider range looks more human
 const MAX_ACTIONS_PER_RUN = 1
 
 function getSupabase() {
@@ -177,6 +178,37 @@ function getSupabase() {
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     { realtime: { transport: ws as unknown as typeof WebSocket } }
   )
+}
+
+/**
+ * Notify the user by email that their LinkedIn session expired and they need
+ * to reconnect. Called after markSessionExpired so the user doesn't sit
+ * wondering why their pipeline stopped.
+ *
+ * Best-effort — never throws so it never blocks the worker loop.
+ */
+async function notifySessionExpired(userId: string, linkedinEmail: string): Promise<void> {
+  try {
+    const appUrl   = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL
+    const secret   = process.env.WORKER_SECRET
+    if (!appUrl || !secret) {
+      console.warn('[worker] NEXT_PUBLIC_APP_URL or WORKER_SECRET not set — skipping session-expired notification')
+      return
+    }
+    const res = await fetch(`${appUrl}/api/gtm/notify/session-expired`, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${secret}` },
+      body:    JSON.stringify({ userId, linkedinEmail }),
+    })
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      console.error(`[worker] session-expired notification failed (${res.status}):`, body)
+    } else {
+      console.log(`[worker] session-expired notification sent for ${linkedinEmail}`)
+    }
+  } catch (err) {
+    console.error('[worker] session-expired notification threw:', err)
+  }
 }
 
 function randomDelay(minMs: number, maxMs: number): Promise<void> {
@@ -249,14 +281,23 @@ async function processItem(
       break
 
     case 'message':
-      if (!profileId) throw new Error('Cannot message: no linkedin_profile_id and could not extract from URL')
-      await sendLinkedInMessage(context, profileId, item.message ?? '')
+    case 'follow_up': {
+      if (!profileId) throw new Error(`Cannot ${item.action}: no linkedin_profile_id and could not extract from URL`)
+      // Before sending a follow-up, confirm the connection was accepted.
+      // If they haven't accepted yet the message will fail (can't DM a non-connection).
+      // Throw NOT_YET_CONNECTED so the caller can reschedule without burning an attempt.
+      const profileUrl = lead.linkedin_url || `https://www.linkedin.com/in/${profileId}/`
+      const accepted = await checkConnectionAccepted(context, profileUrl)
+      if (!accepted) {
+        throw new Error(`NOT_YET_CONNECTED: ${profileId} has not accepted the invitation yet — rescheduling`)
+      }
+      if (item.action === 'message') {
+        await sendLinkedInMessage(context, profileId, item.message ?? '')
+      } else {
+        await sendFollowUp(context, profileId, item.message ?? '')
+      }
       break
-
-    case 'follow_up':
-      if (!profileId) throw new Error('Cannot follow_up: no linkedin_profile_id and could not extract from URL')
-      await sendFollowUp(context, profileId, item.message ?? '')
-      break
+    }
 
     default:
       throw new Error(`Unknown action: ${item.action}`)
@@ -346,6 +387,7 @@ async function runForUser(userId: string, items: QueueItem[]): Promise<void> {
     if (feedUrl.includes('/login') || feedUrl.includes('/checkpoint') || feedUrl.includes('/authwall')) {
       console.warn(`[worker] feed redirected to ${feedUrl} — session expired for ${session.linkedin_email}`)
       await markSessionExpired(session.id)
+      notifySessionExpired(userId, session.linkedin_email).catch(() => {})
       await context.close().catch(() => {})
       contextCache.delete(userId)
       return
@@ -366,6 +408,7 @@ async function runForUser(userId: string, items: QueueItem[]): Promise<void> {
     if (!sessionValid) {
       console.warn(`[worker] feed loaded but no authenticated content — session invalid for ${session.linkedin_email}`)
       await markSessionExpired(session.id)
+      notifySessionExpired(userId, session.linkedin_email).catch(() => {})
       await context.close().catch(() => {})
       contextCache.delete(userId)
       return
@@ -431,16 +474,38 @@ async function runForUser(userId: string, items: QueueItem[]): Promise<void> {
 
       if (msg.includes('SESSION_EXPIRED')) {
         await markSessionExpired(session.id)
+        notifySessionExpired(userId, session.linkedin_email).catch(() => {})
         await context.close().catch(() => {})
         contextCache.delete(userId)
         console.warn(`[worker] session expired mid-run for ${session.linkedin_email} — stopping`)
         break
       }
 
-      // Auth wall is NOT a session expiry — the session is valid but the SPA
-      // didn't bootstrap properly. Don't mark expired; just let it retry.
+      // Connection not yet accepted — reschedule for 24h later without
+      // consuming an attempt. We'll keep checking daily until accepted.
+      if (msg.includes('NOT_YET_CONNECTED')) {
+        const retryAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+        console.log(`[worker] connection pending for item ${item.id} — rescheduling for ${retryAt}`)
+        await supabase
+          .from('linkedin_queue')
+          .update({
+            status: 'queued',
+            scheduled_at: retryAt,
+            attempts: item.attempts, // reset — don't count pending-check as an attempt
+            error: null,
+          })
+          .eq('id', item.id)
+        continue
+      }
+
+      // Auth wall and blank page are NOT session expiries — the session is valid
+      // but LinkedIn temporarily blocked the request (bot detection / rate limit).
+      // Don't mark expired; just let the item retry on the next cycle.
       if (msg.includes('AUTHWALL')) {
         console.warn(`[worker] auth wall for item ${item.id} — will retry without expiring session`)
+      }
+      if (msg.includes('BLANK_PAGE')) {
+        console.warn(`[worker] blank page for item ${item.id} — temporary block, will retry`)
       }
 
       const newStatus = item.attempts + 1 >= 3 ? 'failed' : 'queued'

--- a/workers/linkedin/login.ts
+++ b/workers/linkedin/login.ts
@@ -205,6 +205,21 @@ export async function loginLinkedIn(userId: string): Promise<void> {
   const userDataDir = path.join(PROFILES_DIR, userId)
   fs.mkdirSync(userDataDir, { recursive: true })
 
+  // Kill any Chrome process that still has this profile directory open.
+  // This can happen when a previous login attempt timed out or was interrupted
+  // while the browser was still running (e.g. waiting for push-notification 2FA).
+  // Without this, launchPersistentContext throws "Opening in existing browser session".
+  try {
+    const { execSync } = await import('child_process')
+    // pkill -f matches the full command line; || true prevents non-zero exit when no match
+    execSync(`pkill -f "user-data-dir=${userDataDir}" 2>/dev/null || true`, { stdio: 'ignore' })
+    // Give Chrome 2 s to fully exit and release file handles
+    await new Promise(r => setTimeout(r, 2000))
+  } catch { /* not on Linux or no matching process — safe to ignore */ }
+
+  // Remove Chrome's SingletonLock if it wasn't cleaned up (crash / SIGKILL)
+  try { fs.unlinkSync(path.join(userDataDir, 'SingletonLock')) } catch { /* already gone */ }
+
   // Prefer Google Chrome — better JA3/JA4 TLS fingerprint than Playwright Chromium
   const chromeExecutable = process.env.CHROME_EXECUTABLE_PATH ??
     ['/usr/bin/google-chrome-stable', '/usr/bin/google-chrome', '/usr/bin/chromium-browser']
@@ -236,10 +251,38 @@ export async function loginLinkedIn(userId: string): Promise<void> {
     // Navigate to login page
     await page.goto('https://www.linkedin.com/login', { waitUntil: 'load', timeout: 60_000 })
 
-    // Wait for any input to be attached (in DOM) — not necessarily Playwright-"visible"
-    await page.waitForSelector('input', { state: 'attached', timeout: 30_000 }).catch(async () => {
+    // If LinkedIn redirected us to /feed/ it means the persistent profile
+    // directory already has a valid session — skip the form entirely.
+    if (page.url().includes('/feed') || page.url() === 'https://www.linkedin.com/') {
+      console.log(`[login] already authenticated in profile dir — saving existing cookies`)
+      const cookies = await context.cookies()
+      const liAt = cookies.find(c => c.name === 'li_at')
+      if (liAt) {
+        const sessionData = { cookies, userAgent: DEFAULT_UA }
+        const encrypted = encrypt(JSON.stringify(sessionData))
+        await setSessionStatus(sessionId, 'active', { login_error: null, verification_code: null })
+        await getSupabase()
+          .from('linkedin_sessions')
+          .update({ session_cookies: encrypted, last_used_at: new Date().toISOString() })
+          .eq('id', sessionId)
+        console.log(`[login] ✓ logged in successfully as ${email} (existing session)`)
+        return
+      }
+      // li_at missing despite being on feed — fall through to login form
+      console.log(`[login] on feed but no li_at cookie — proceeding with login form`)
+      await page.goto('https://www.linkedin.com/login', { waitUntil: 'load', timeout: 60_000 })
+    }
+
+    // Wait for the visible email input to be ready — LinkedIn renders two copies
+    // of the form (a hidden server-rendered version and a visible React-hydrated
+    // version). Playwright's :visible pseudo-class targets the hydrated one.
+    const emailInput = page.locator(
+      // autocomplete may be "username webauthn" — use ~= (word match) not exact =
+      'input[type="email"]:visible, input#username:visible, input[autocomplete~="username"]:visible'
+    ).first()
+    await emailInput.waitFor({ state: 'visible', timeout: 30_000 }).catch(async () => {
       const bodySnippet = (await page.innerText('body').catch(() => '')).slice(0, 400).replace(/\s+/g, ' ')
-      console.error(`[login] no inputs found. url=${page.url()} body="${bodySnippet}"`)
+      console.error(`[login] email field not found. url=${page.url()} body="${bodySnippet}"`)
       throw new Error('LinkedIn login page did not load — please try again.')
     })
 
@@ -253,82 +296,34 @@ export async function loginLinkedIn(userId: string): Promise<void> {
     ).catch(() => 'evaluate failed')
     console.log(`[login] DOM inputs: ${domInputs || 'NONE'}`)
 
-    // LinkedIn's login page renders two copies of the form: a server-rendered
-    // (hidden) version and a React-hydrated (visible) version. The hidden fields
-    // have offsetParent===null; we must target the visible ones, otherwise
-    // credentials are typed into the hidden form and nothing submits.
-    const emailFocused = await page.evaluate(() => {
-      const visible = (el: Element) => (el as HTMLElement).offsetParent !== null
-      const field = (
-        document.querySelector('input#username') ||
-        document.querySelector('input[name="session_key"]') ||
-        document.querySelector('input[autocomplete="username"]') ||
-        // Prefer the first VISIBLE email/text input
-        Array.from(document.querySelectorAll('input[type="email"]')).find(visible) ||
-        Array.from(document.querySelectorAll('input[type="text"]')).find(visible)
-      ) as HTMLInputElement | null
-      if (!field) return false
-      field.focus()
-      return true
-    })
-
-    if (!emailFocused) {
-      const bodySnippet = (await page.innerText('body').catch(() => '')).slice(0, 400).replace(/\s+/g, ' ')
-      console.error(`[login] email field not found in DOM. url=${page.url()} body="${bodySnippet}"`)
-      throw new Error('LinkedIn login page did not load — please try again.')
-    }
-
-    await page.keyboard.type(email, { delay: 40 + Math.random() * 60 })
+    // fill() sets the value AND fires the input/change events React needs to
+    // update its controlled-component state. evaluate(focus)+keyboard.type()
+    // only updates the DOM value — React never sees it, so it submits empty.
+    await emailInput.fill(email)
     console.log('[login] email filled')
     await page.waitForTimeout(500 + Math.random() * 500)
 
-    // Focus the first VISIBLE password input
-    await page.evaluate(() => {
-      const visible = (el: Element) => (el as HTMLElement).offsetParent !== null
-      const field = (
-        document.querySelector('input#password') ||
-        document.querySelector('input[name="session_password"]') ||
-        Array.from(document.querySelectorAll('input[type="password"]')).find(visible)
-      ) as HTMLInputElement | null
-      field?.focus()
-    })
-    await page.keyboard.type(password, { delay: 40 + Math.random() * 60 })
+    const passwordInput = page.locator('input[type="password"]:visible').first()
+    await passwordInput.waitFor({ state: 'visible', timeout: 10_000 })
+    await passwordInput.fill(password)
     console.log('[login] password filled')
     await page.waitForTimeout(1000 + Math.random() * 500)
 
-    // Log the button that's inside the email/password form (for diagnostics)
-    const btnInfo = await page.evaluate(() => {
-      const visible = (el: Element) => (el as HTMLElement).offsetParent !== null
-      // Walk from the visible password field up to its parent <form>
-      const pwField = Array.from(document.querySelectorAll('input[type="password"]'))
-        .find(visible) as HTMLElement | null
-      const form = pwField?.closest('form') as HTMLFormElement | null
-      const btn = (form?.querySelector('button[type="submit"]') ||
-                   form?.querySelector('button')) as HTMLButtonElement | null
-      return btn ? `disabled=${btn.disabled} text="${btn.textContent?.trim()}"` : 'NOT FOUND'
-    })
-    console.log(`[login] submit button: ${btnInfo}`)
-
-    // Submit via Enter key (most natural — fires on the focused password field)
-    await page.keyboard.press('Enter')
+    // Submit: press Enter on the focused password locator (natural form submission)
+    await passwordInput.press('Enter')
     await page.waitForTimeout(1000)
 
-    // Fallback: click the submit button INSIDE the email/password form.
-    // We find it by walking from the visible password input to its <form>, then
-    // clicking that form's button. This avoids the SSO buttons ("Sign in with
-    // Microsoft / Apple") that appear first in the DOM as visible buttons and
-    // would otherwise be selected by a naïve find(visible) search.
-    await page.evaluate(() => {
-      const visible = (el: Element) => (el as HTMLElement).offsetParent !== null
-      const pwField = Array.from(document.querySelectorAll('input[type="password"]'))
-        .find(visible) as HTMLElement | null
-      const form = pwField?.closest('form') as HTMLFormElement | null
-      if (form) {
-        const btn = (form.querySelector('button[type="submit"]') ||
-                     form.querySelector('button')) as HTMLButtonElement | null
-        btn ? btn.click() : form.submit()
-      }
-    })
+    // Fallback: click the Sign-In button using exact-text match to avoid selecting
+    // SSO buttons ("Sign in with Microsoft / Apple" etc.).
+    // Covers English, Portuguese, Spanish, French, German variants.
+    const signInBtn = page.locator('button').filter({
+      hasText: /^(Sign in|Sign In|Log in|Entrar|Iniciar sesión|Se connecter|Anmelden|Ingresar|Submit|Accedi|Inloggen)$/i,
+    }).first()
+    const signInBtnText = await signInBtn.textContent({ timeout: 2_000 }).catch(() => null)
+    console.log(`[login] submit button: ${signInBtnText ? `found — "${signInBtnText.trim()}"` : 'NOT FOUND (Enter already sent)'}`)
+    if (signInBtnText) {
+      await signInBtn.click()
+    }
     await page.waitForTimeout(4000)
 
     const postLoginUrl = page.url()


### PR DESCRIPTION
## Summary

- **Login**: Switched from session-cookie paste to `launchPersistentContext` (Patchright). Login survives restarts — detects already-authenticated browser profiles and restores without re-login. Fixes React input hydration by using `locator.fill()`. Exact-text Sign In button match prevents \"Sign in with Microsoft\" false match.

- **Connect flow**: Modal-first approach — waits up to 6s for the \"Add a note\" modal before falling back to direct-send detection. Real Playwright click (not `dispatchEvent`) so LinkedIn's full click handler fires. Robust Pending detection via `page.evaluate` (immune to React re-render timing gaps).

- **Human behavior**: `humanWander()` scrolls feed naturally, hovers profile links, 30% chance visits /notifications/. Profile scroll before Connect. ACTION_DELAY raised to 3–7 min between actions.

- **Follow-up sequence**: `checkConnectionAccepted()` before messaging. `NOT_YET_CONNECTED` reschedules item 24h later. `BLANK_PAGE` error type doesn't expire session (temporary bot block, retries).

- **Session expiry notifications**: New `POST /api/gtm/notify/session-expired` route sends a ZeptoMail reconnect email when the worker marks a session as `needs_login`. New branded email template at `emails/linkedin-session-expired.html`.

- **Frontend**: Removed session-cookie login entirely from settings page — email+password is now the only connect method. Removed cookie state, cookie form, mode toggle, and `connectLinkedInCookie()`. Renamed confusing \"Reconnect\" button to \"Remove\".

## Test plan

- [ ] LinkedIn connect via email+password works end-to-end (including 2FA push notification)
- [ ] Already-authenticated browser profile detected on reconnect (no re-login)
- [ ] Connect actions fire with human wander before each profile visit
- [ ] Note modal detected and note attached when LinkedIn shows it
- [ ] Direct-send correctly detected (Pending button) without WARNING log
- [ ] Session expiry email sent when worker marks session needs_login
- [ ] Settings page shows only email+password form (no cookie option)

🤖 Generated with [Claude Code](https://claude.com/claude-code)